### PR TITLE
feat: add telefono and mail fields to cliente selection in entrega repository

### DIFF
--- a/src/models/Entrega/entrega.controller.ts
+++ b/src/models/Entrega/entrega.controller.ts
@@ -27,7 +27,7 @@ export class EntregaController {
   }
 
   async getOne(req: Request, res: Response) {
-    const cod_entrega = parseInt(req.params.cod_entrega)
+    const cod_entrega = parseInt(req.params.id)
     const entrega = await entregaService.findById(cod_entrega)
     if (!entrega) {
       return res.status(404).json({ message: 'Entrega no encontrada' })
@@ -36,13 +36,13 @@ export class EntregaController {
   }
 
   async update(req: Request, res: Response) {
-    const cod_entrega = parseInt(req.params.cod_entrega)
+    const cod_entrega = parseInt(req.params.id)
     const entrega = await entregaService.update(cod_entrega, req.body)
     res.json(entrega)
   }
 
   async remove(req: Request, res: Response) {
-    const cod_entrega = parseInt(req.params.cod_entrega)
+    const cod_entrega = parseInt(req.params.id)
     const entrega = await entregaService.delete(cod_entrega)
     res.json(entrega)
   }

--- a/src/models/Entrega/entrega.repository.ts
+++ b/src/models/Entrega/entrega.repository.ts
@@ -53,6 +53,8 @@ export class EntregaRepository {
             cliente: {
               select: {
                 razon_social: true,
+                telefono: true,
+                mail: true,
               },
             },
           },

--- a/src/models/Entrega/entrega.repository.ts
+++ b/src/models/Entrega/entrega.repository.ts
@@ -50,6 +50,9 @@ export class EntregaRepository {
           select: {
             cod_obra: true,
             direccion: true,
+            localidad: {
+              select: { cod_postal: true, nombre_localidad: true },
+            },
             cliente: {
               select: {
                 razon_social: true,

--- a/src/models/Entrega/entrega.routes.ts
+++ b/src/models/Entrega/entrega.routes.ts
@@ -4,7 +4,7 @@ import { validate } from '../../shared/middlewares/validateSchemas.js'
 import {
   createEntregaSchema,
   updateEntregaSchema,
-  cuilParamsSchema,
+  idParamsSchema,
 } from 'sigma-la-schemas'
 const entregaController = new EntregaController()
 const entregaRouter = Router()
@@ -22,18 +22,14 @@ entregaRouter.post('/', validate({ body: createEntregaSchema }), (req, res) => {
   entregaController.create(req, res)
 })
 
-entregaRouter.get(
-  '/:cod_entrega',
-  validate({ params: cuilParamsSchema }),
-  (req, res) => {
-    entregaController.getOne(req, res)
-  },
-)
+entregaRouter.get('/:id', validate({ params: idParamsSchema }), (req, res) => {
+  entregaController.getOne(req, res)
+})
 
 entregaRouter.put(
-  '/:cod_entrega',
+  '/:id',
   validate({
-    params: cuilParamsSchema,
+    params: idParamsSchema,
     body: updateEntregaSchema,
   }),
   (req, res) => {
@@ -42,8 +38,8 @@ entregaRouter.put(
 )
 
 entregaRouter.delete(
-  '/:cod_entrega',
-  validate({ params: cuilParamsSchema }),
+  '/:id',
+  validate({ params: idParamsSchema }),
   (req, res) => {
     entregaController.remove(req, res)
   },

--- a/src/models/EntregaEmpleado/entregaEmpleado.controller.ts
+++ b/src/models/EntregaEmpleado/entregaEmpleado.controller.ts
@@ -30,7 +30,7 @@ export class EntregaEmpleadoController {
 
   async getOne(req: Request, res: Response) {
     try {
-      const cod_entrega = Number(req.params.cod_entrega)
+      const cod_entrega = Number(req.params.id)
       const cuil = req.params.cuil
       const relacion = await entregaEmpleadoService.findById(cod_entrega, cuil)
 
@@ -51,7 +51,7 @@ export class EntregaEmpleadoController {
 
   async update(req: Request, res: Response) {
     try {
-      const cod_entrega = Number(req.params.cod_entrega)
+      const cod_entrega = Number(req.params.id)
       const cuil = req.params.cuil
       const relacion = await entregaEmpleadoService.update(
         cod_entrega,
@@ -69,7 +69,7 @@ export class EntregaEmpleadoController {
 
   async remove(req: Request, res: Response) {
     try {
-      const cod_entrega = Number(req.params.cod_entrega)
+      const cod_entrega = Number(req.params.id)
       const cuil = req.params.cuil
       const relacion = await entregaEmpleadoService.delete(cod_entrega, cuil)
       res.json(relacion)

--- a/src/models/EntregaEmpleado/entregaEmpleado.routes.ts
+++ b/src/models/EntregaEmpleado/entregaEmpleado.routes.ts
@@ -12,15 +12,15 @@ entregaEmpleadoRouter.post('/', (req, res) => {
   entregaEmpleadoController.create(req, res)
 })
 
-entregaEmpleadoRouter.get('/:cod_entrega/:cuil', (req, res) => {
+entregaEmpleadoRouter.get('/:id/:cuil', (req, res) => {
   entregaEmpleadoController.getOne(req, res)
 })
 
-entregaEmpleadoRouter.put('/:cod_entrega/:cuil', (req, res) => {
+entregaEmpleadoRouter.put('/:id/:cuil', (req, res) => {
   entregaEmpleadoController.update(req, res)
 })
 
-entregaEmpleadoRouter.delete('/:cod_entrega/:cuil', (req, res) => {
+entregaEmpleadoRouter.delete('/:id/:cuil', (req, res) => {
   entregaEmpleadoController.remove(req, res)
 })
 

--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -44,6 +44,57 @@ export class VisitaController {
     const visita = await visitaService.remove(Number(id))
     res.json(visita)
   }
+
+  async getVisitasByEmpleadoAndEstado(req: Request, res: Response) {
+    try {
+      const cuil = req.params.cuil
+      const estado = req.params.estado as
+        | 'PROGRAMADA'
+        | 'EN CURSO'
+        | 'CANCELADA'
+        | 'REPROGRAMADA'
+        | 'COMPLETADA'
+
+      const visitas = await visitaService.getVisitasByEmpleadoAndEstado(
+        cuil,
+        estado,
+      )
+      res.status(200).json(visitas)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener visitas por empleado y estado',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  // Obtener todas las visitas de un empleado
+  async getVisitasByEmpleado(req: Request, res: Response) {
+    try {
+      const cuil = req.params.cuil
+      const visitas = await visitaService.getVisitasByEmpleado(cuil)
+      res.status(200).json(visitas)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener visitas del empleado',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  // Obtener visitas por obra
+  async getVisitasByObra(req: Request, res: Response) {
+    try {
+      const cod_obra = Number(req.params.cod_obra)
+      const visitas = await visitaService.getVisitasByObra(cod_obra)
+      res.status(200).json(visitas)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener visitas de la obra',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
 }
 
 export const visitaController = new VisitaController()

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -71,9 +71,30 @@ export class VisitaRepository {
       },
       data,
       include: {
-        obra: true,
+        obra: {
+          include: {
+            cliente: {
+              select: {
+                razon_social: true,
+                telefono: true,
+                mail: true,
+              },
+            },
+          },
+        },
         localidad: true,
-        empleado_visita: true,
+        empleado_visita: {
+          include: {
+            empleado: {
+              select: {
+                cuil: true,
+                nombre: true,
+                apellido: true,
+                rol_actual: true,
+              },
+            },
+          },
+        },
         uso_vehiculo_visita: {
           include: {
             vehiculo: true,

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -127,6 +127,104 @@ export class VisitaRepository {
       },
     })
   }
+  async findByEmpleadoAndEstado(
+    cuil: string,
+    estado: string,
+  ): Promise<visita[]> {
+    return await this.prisma.visita.findMany({
+      where: {
+        estado: estado,
+        empleado_visita: {
+          some: {
+            cuil: cuil,
+          },
+        },
+      },
+      include: {
+        obra: {
+          select: {
+            cod_obra: true,
+            direccion: true,
+            cliente: {
+              select: {
+                razon_social: true,
+                telefono: true,
+                mail: true,
+              },
+            },
+          },
+        },
+        empleado_visita: {
+          include: {
+            empleado: {
+              select: {
+                cuil: true,
+                nombre: true,
+                apellido: true,
+                rol_actual: true,
+              },
+            },
+          },
+        },
+        localidad: {
+          select: {
+            cod_postal: true,
+            nombre_localidad: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha_hora_visita: 'desc',
+      },
+    })
+  }
+
+  // Obtener todas las visitas de un empleado
+  async findByEmpleado(cuil: string): Promise<visita[]> {
+    return await this.prisma.visita.findMany({
+      where: {
+        empleado_visita: {
+          some: {
+            cuil: cuil,
+          },
+        },
+      },
+      include: {
+        obra: {
+          select: {
+            cod_obra: true,
+            direccion: true,
+            cliente: {
+              select: {
+                razon_social: true,
+              },
+            },
+          },
+        },
+        empleado_visita: {
+          include: {
+            empleado: {
+              select: {
+                cuil: true,
+                nombre: true,
+                apellido: true,
+                rol_actual: true,
+              },
+            },
+          },
+        },
+        localidad: {
+          select: {
+            cod_postal: true,
+            nombre_localidad: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha_hora_visita: 'desc',
+      },
+    })
+  }
 }
 
 export const visitaRepository = new VisitaRepository()

--- a/src/models/Visita/visita.routes.ts
+++ b/src/models/Visita/visita.routes.ts
@@ -41,4 +41,18 @@ visitaRouter.delete(
   },
 )
 
+visitaRouter.get('/empleado/:cuil/:estado', (req, res) => {
+  visitaController.getVisitasByEmpleadoAndEstado(req, res)
+})
+
+// GET /api/visitas/empleado/:cuil - Todas las visitas de un empleado
+visitaRouter.get('/empleado/:cuil', (req, res) => {
+  visitaController.getVisitasByEmpleado(req, res)
+})
+
+// GET /api/visitas/obra/:cod_obra - Visitas asociadas a una obra
+visitaRouter.get('/obra/:cod_obra', (req, res) => {
+  visitaController.getVisitasByObra(req, res)
+})
+
 export default visitaRouter

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -9,6 +9,9 @@ import { visita, Prisma } from '@prisma/client'
  * @method findById - Obtiene una visita por su cod_visita.
  * @method update - Actualiza una visita existente verificando que existe.
  * @method remove - Elimina una visita por su cod_visita verificando que existe.
+ * @method getVisitasByEmpleadoAndEstado - Obtiene visitas de un empleado por estado específico.
+ * @method getVisitasByEmpleado - Obtiene todas las visitas de un empleado.
+ * @method getVisitasByObra - Obtiene visitas asociadas a una obra.
  * @returns {Promise<visita | visita[] | null>} - Resultado de la operación.
  * @throws {Error} - Si ocurre un error durante la operación.
  */
@@ -141,6 +144,27 @@ export class VisitaService {
 
   // Obtener visitas por obra
   async findByObra(cod_obra: number): Promise<visita[]> {
+    return await this.visitaRepository.findByObra(cod_obra)
+  }
+  async getVisitasByEmpleadoAndEstado(
+    cuil: string,
+    estado:
+      | 'PROGRAMADA'
+      | 'EN CURSO'
+      | 'CANCELADA'
+      | 'REPROGRAMADA'
+      | 'COMPLETADA',
+  ): Promise<visita[]> {
+    return await this.visitaRepository.findByEmpleadoAndEstado(cuil, estado)
+  }
+
+  // Obtener todas las visitas de un empleado
+  async getVisitasByEmpleado(cuil: string): Promise<visita[]> {
+    return await this.visitaRepository.findByEmpleado(cuil)
+  }
+
+  // Obtener visitas asociadas a una obra (usando el método existente con nombre más específico)
+  async getVisitasByObra(cod_obra: number): Promise<visita[]> {
     return await this.visitaRepository.findByObra(cod_obra)
   }
 }

--- a/src/models/VisitaEmpleado/visitaEmpleado.controller.ts
+++ b/src/models/VisitaEmpleado/visitaEmpleado.controller.ts
@@ -1,0 +1,83 @@
+import { VisitaEmpleadoService } from './visitaEmpleado.service.js'
+import { Request, Response } from 'express'
+
+const visitaEmpleadoService = new VisitaEmpleadoService()
+
+export class VisitaEmpleadoController {
+  async create(req: Request, res: Response) {
+    try {
+      const nuevaRelacion = await visitaEmpleadoService.create(req.body)
+      res.status(201).json(nuevaRelacion)
+    } catch (error) {
+      res.status(400).json({
+        message: 'Error al crear relación empleado-visita',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  async getAll(req: Request, res: Response) {
+    try {
+      const relaciones = await visitaEmpleadoService.findAll()
+      res.status(200).json(relaciones)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener relaciones empleado-visita',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  async getOne(req: Request, res: Response) {
+    try {
+      const cuil = req.params.cuil
+      const cod_visita = Number(req.params.cod_visita)
+      const relacion = await visitaEmpleadoService.findById(cuil, cod_visita)
+
+      if (!relacion) {
+        return res.status(404).json({
+          message: 'Relación empleado-visita no encontrada',
+        })
+      }
+
+      res.json(relacion)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener relación empleado-visita',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  async update(req: Request, res: Response) {
+    try {
+      const cuil = req.params.cuil
+      const cod_visita = Number(req.params.cod_visita)
+      const relacion = await visitaEmpleadoService.update(
+        cuil,
+        cod_visita,
+        req.body,
+      )
+      res.json(relacion)
+    } catch (error) {
+      res.status(400).json({
+        message: 'Error al actualizar relación empleado-visita',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+
+  async remove(req: Request, res: Response) {
+    try {
+      const cuil = req.params.cuil
+      const cod_visita = Number(req.params.cod_visita)
+      const relacion = await visitaEmpleadoService.delete(cuil, cod_visita)
+      res.json(relacion)
+    } catch (error) {
+      res.status(400).json({
+        message: 'Error al eliminar relación empleado-visita',
+        error: error instanceof Error ? error.message : 'Error desconocido',
+      })
+    }
+  }
+}

--- a/src/models/VisitaEmpleado/visitaEmpleado.repository.ts
+++ b/src/models/VisitaEmpleado/visitaEmpleado.repository.ts
@@ -1,0 +1,83 @@
+import { PrismaClient, empleado_visita, Prisma } from '@prisma/client'
+import { prisma } from '../../shared/db/prismaClient.js'
+
+export class VisitaEmpleadoRepository {
+  private prisma: PrismaClient
+
+  constructor() {
+    this.prisma = prisma
+  }
+
+  async create(
+    data: Prisma.empleado_visitaCreateInput,
+  ): Promise<empleado_visita> {
+    return await this.prisma.empleado_visita.create({ data })
+  }
+
+  async findAll(): Promise<empleado_visita[]> {
+    return await this.prisma.empleado_visita.findMany({
+      include: {
+        empleado: {
+          select: {
+            nombre: true,
+            apellido: true,
+            rol_actual: true,
+          },
+        },
+        visita: {
+          select: {
+            fecha_hora_visita: true,
+            estado: true,
+            motivo_visita: true,
+            direccion_visita: true,
+          },
+        },
+      },
+    })
+  }
+
+  async findById(
+    cuil: string,
+    cod_visita: number,
+  ): Promise<empleado_visita | null> {
+    return await this.prisma.empleado_visita.findUnique({
+      where: {
+        cuil_cod_visita: {
+          cuil: cuil,
+          cod_visita: cod_visita,
+        },
+      },
+      include: {
+        empleado: true,
+        visita: true,
+      },
+    })
+  }
+
+  async update(
+    cuil: string,
+    cod_visita: number,
+    data: Prisma.empleado_visitaUpdateInput,
+  ): Promise<empleado_visita> {
+    return await this.prisma.empleado_visita.update({
+      where: {
+        cuil_cod_visita: {
+          cuil: cuil,
+          cod_visita: cod_visita,
+        },
+      },
+      data,
+    })
+  }
+
+  async delete(cuil: string, cod_visita: number): Promise<empleado_visita> {
+    return await this.prisma.empleado_visita.delete({
+      where: {
+        cuil_cod_visita: {
+          cuil: cuil,
+          cod_visita: cod_visita,
+        },
+      },
+    })
+  }
+}

--- a/src/models/VisitaEmpleado/visitaEmpleado.routes.ts
+++ b/src/models/VisitaEmpleado/visitaEmpleado.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express'
+import { VisitaEmpleadoController } from './visitaEmpleado.controller.js'
+
+const visitaEmpleadoController = new VisitaEmpleadoController()
+const visitaEmpleadoRouter = Router()
+
+visitaEmpleadoRouter.get('/', (req, res) => {
+  visitaEmpleadoController.getAll(req, res)
+})
+
+visitaEmpleadoRouter.post('/', (req, res) => {
+  visitaEmpleadoController.create(req, res)
+})
+
+visitaEmpleadoRouter.get('/:cuil/:cod_visita', (req, res) => {
+  visitaEmpleadoController.getOne(req, res)
+})
+
+visitaEmpleadoRouter.put('/:cuil/:cod_visita', (req, res) => {
+  visitaEmpleadoController.update(req, res)
+})
+
+visitaEmpleadoRouter.delete('/:cuil/:cod_visita', (req, res) => {
+  visitaEmpleadoController.remove(req, res)
+})
+
+export default visitaEmpleadoRouter

--- a/src/models/VisitaEmpleado/visitaEmpleado.service.ts
+++ b/src/models/VisitaEmpleado/visitaEmpleado.service.ts
@@ -1,0 +1,43 @@
+import { empleado_visita, Prisma } from '@prisma/client'
+import { VisitaEmpleadoRepository } from './visitaEmpleado.repository.js'
+
+export class VisitaEmpleadoService {
+  private repository: VisitaEmpleadoRepository
+
+  constructor() {
+    this.repository = new VisitaEmpleadoRepository()
+  }
+
+  async create(
+    data: Prisma.empleado_visitaCreateInput,
+  ): Promise<empleado_visita> {
+    return await this.repository.create(data)
+  }
+
+  async findAll(): Promise<empleado_visita[]> {
+    return this.repository.findAll()
+  }
+
+  async findById(
+    cuil: string,
+    cod_visita: number,
+  ): Promise<empleado_visita | null> {
+    return await this.repository.findById(cuil, cod_visita)
+  }
+
+  async update(
+    cuil: string,
+    cod_visita: number,
+    data: Prisma.empleado_visitaUpdateInput,
+  ): Promise<empleado_visita> {
+    return await this.repository.update(cuil, cod_visita, data)
+  }
+
+  async delete(cuil: string, cod_visita: number): Promise<empleado_visita> {
+    const existingRelacion = await this.repository.findById(cuil, cod_visita)
+    if (!existingRelacion) {
+      throw new Error('Relación empleado-visita no encontrada')
+    }
+    return await this.repository.delete(cuil, cod_visita)
+  }
+}

--- a/src/shared/db/seeder.ts
+++ b/src/shared/db/seeder.ts
@@ -16,8 +16,8 @@ async function post(url: string, data: Record<string, unknown>) {
 async function seed() {
   // Localidades
   await post(`${API_URL}/api/localidades`, {
-    cod_postal: 1000,
-    nombre_localidad: 'Ciudad Uno',
+    cod_postal: 2000,
+    nombre_localidad: 'Rosario',
   })
   await post(`${API_URL}/api/localidades`, {
     cod_postal: 2200,
@@ -25,37 +25,57 @@ async function seed() {
   })
   await post(`${API_URL}/api/localidades`, {
     cod_postal: 3000,
-    nombre_localidad: 'Ciudad Tres',
+    nombre_localidad: 'Santa Fe',
+  })
+  await post(`${API_URL}/api/localidades`, {
+    cod_postal: 1900,
+    nombre_localidad: 'La Plata',
+  })
+  await post(`${API_URL}/api/localidades`, {
+    cod_postal: 5000,
+    nombre_localidad: 'Córdoba',
   })
   await post(`${API_URL}/api/localidades`, {
     cod_postal: 4000,
-    nombre_localidad: 'Ciudad Cuatro',
+    nombre_localidad: 'San Miguel de Tucumán',
   })
 
   // Clientes
   await post(`${API_URL}/api/clientes`, {
     cuil: '20111111111',
-    razon_social: 'Cliente Uno',
+    razon_social: 'Constructora San Martín S.A.',
     telefono: '+54 9 11 1234 5678',
-    mail: 'uno@cliente.com',
+    mail: 'contacto@constructorasanmartin.com.ar',
   })
   await post(`${API_URL}/api/clientes`, {
     cuil: '20222222222',
-    razon_social: 'Cliente Dos',
-    telefono: '+54 9 11 2345 6789',
-    mail: 'dos@cliente.com',
+    razon_social: 'Edificaciones del Litoral S.R.L.',
+    telefono: '+54 9 11 1234 5678',
+    mail: 'ventas@edificacionesdellitoral.com.ar',
   })
   await post(`${API_URL}/api/clientes`, {
     cuil: '20333333333',
-    razon_social: 'Cliente Tres',
-    telefono: '+54 9 11 3456 7890',
-    mail: 'tres@cliente.com',
+    razon_social: 'Desarrollos Urbanos Santa Fe S.A.',
+    telefono: '+54 9 11 1234 5678',
+    mail: 'proyectos@desarrollosurbanos.com.ar',
   })
   await post(`${API_URL}/api/clientes`, {
     cuil: '20444444444',
-    razon_social: 'Cliente Cuatro',
-    telefono: '+54 9 11 4567 8901',
-    mail: 'cuatro@cliente.com',
+    razon_social: 'Inmobiliaria La Plata S.A.',
+    telefono: '+54 9 11 1234 5678',
+    mail: 'info@inmobiliarialaplata.com.ar',
+  })
+  await post(`${API_URL}/api/clientes`, {
+    cuil: '20555555555',
+    razon_social: 'Construcciones Córdoba Norte S.R.L.',
+    telefono: '+54 9 11 1234 5678',
+    mail: 'administracion@cordobanorte.com.ar',
+  })
+  await post(`${API_URL}/api/clientes`, {
+    cuil: '20666666666',
+    razon_social: 'Grupo Constructor Tucumán S.A.',
+    telefono: '+54 9 11 1234 5678',
+    mail: 'gerencia@constructortucuman.com.ar',
   })
 
   // Empleados - Roles únicos
@@ -137,12 +157,12 @@ async function seed() {
   // Obras
   await post(`${API_URL}/api/obras`, {
     cod_obra: 1,
-    cod_postal: 1000,
+    cod_postal: 2000,
     cuil: '20111111111',
     fecha_ini: '2025-09-01',
     estado: 'ACTIVA',
-    direccion: 'Calle 1',
-    nota_fabrica: 'Nota 1',
+    direccion: 'Av. Pellegrini 1250, Rosario',
+    nota_fabrica: 'Edificio residencial de 12 pisos - Torre Pellegrini',
   })
   await post(`${API_URL}/api/obras`, {
     cod_obra: 2,
@@ -150,8 +170,8 @@ async function seed() {
     cuil: '20222222222',
     fecha_ini: '2025-09-02',
     estado: 'ACTIVA',
-    direccion: 'Calle 2',
-    nota_fabrica: 'Nota 2',
+    direccion: 'Av. San Martín 850, San Lorenzo',
+    nota_fabrica: 'Complejo habitacional - 40 unidades',
   })
   await post(`${API_URL}/api/obras`, {
     cod_obra: 3,
@@ -159,17 +179,35 @@ async function seed() {
     cuil: '20333333333',
     fecha_ini: '2025-09-03',
     estado: 'ACTIVA',
-    direccion: 'Calle 3',
-    nota_fabrica: 'Nota 3',
+    direccion: 'Bv. Gálvez 1680, Santa Fe',
+    nota_fabrica: 'Centro comercial - 3 plantas',
   })
   await post(`${API_URL}/api/obras`, {
     cod_obra: 4,
-    cod_postal: 4000,
+    cod_postal: 1900,
     cuil: '20444444444',
     fecha_ini: '2025-09-04',
     estado: 'ACTIVA',
-    direccion: 'Calle 4',
-    nota_fabrica: 'Nota 4',
+    direccion: 'Calle 7 entre 47 y 48, La Plata',
+    nota_fabrica: 'Edificio de oficinas - 8 pisos',
+  })
+  await post(`${API_URL}/api/obras`, {
+    cod_obra: 5,
+    cod_postal: 5000,
+    cuil: '20555555555',
+    fecha_ini: '2025-09-05',
+    estado: 'ACTIVA',
+    direccion: 'Av. Colón 4500, Córdoba',
+    nota_fabrica: 'Complejo de viviendas - Barrio Cerro de las Rosas',
+  })
+  await post(`${API_URL}/api/obras`, {
+    cod_obra: 6,
+    cod_postal: 4000,
+    cuil: '20666666666',
+    fecha_ini: '2025-09-06',
+    estado: 'ACTIVA',
+    direccion: 'Av. Aconquija 1200, San Miguel de Tucumán',
+    nota_fabrica: 'Torres gemelas residenciales - 15 pisos c/u',
   })
 
   // Entregas
@@ -177,153 +215,152 @@ async function seed() {
     cod_obra: 1,
     fecha_hora_entrega: '2025-09-05T09:00',
     estado: 'PENDIENTE',
-    detalle: 'Entrega inicial',
-    observaciones: 'Preparar documentación',
+    detalle: 'Entrega de aberturas piso 1-3',
+    observaciones: 'Verificar medidas antes de instalación',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 1,
     fecha_hora_entrega: '2025-09-10T14:00',
     estado: 'EN CURSO',
-    detalle: 'Entrega parcial',
-    observaciones: 'Faltan accesorios',
+    detalle: 'Entrega parcial piso 4-6',
+    observaciones: 'Faltan herrajes de seguridad',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 2,
     fecha_hora_entrega: '2025-09-12T11:30',
     estado: 'ENTREGADO',
-    detalle: 'Entrega completa',
-    observaciones: 'Todo conforme',
+    detalle: 'Entrega completa bloques A y B',
+    observaciones: 'Entrega conforme - documentación firmada',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 2,
     fecha_hora_entrega: '2025-09-15T16:00',
     estado: 'CANCELADO',
-    detalle: 'Entrega cancelada',
-    observaciones: 'Cliente ausente',
+    detalle: 'Entrega bloque C',
+    observaciones: 'Obra suspendida temporalmente por cliente',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 3,
     fecha_hora_entrega: '2025-09-18T10:00',
     estado: 'PENDIENTE',
-    detalle: 'Entrega inicial',
-    observaciones: 'Requiere revisión previa',
+    detalle: 'Aberturas planta baja comercial',
+    observaciones: 'Requiere coordinación con electricista',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 3,
     fecha_hora_entrega: '2025-09-20T13:00',
     estado: 'EN CURSO',
-    detalle: 'Entrega parcial',
-    observaciones: 'Faltan herrajes',
+    detalle: 'Mamparas divisorias primer piso',
+    observaciones: 'Pendiente entrega de vidrios templados',
   })
   await post(`${API_URL}/api/entregas`, {
     cod_obra: 4,
     fecha_hora_entrega: '2025-09-22T15:30',
     estado: 'ENTREGADO',
-    detalle: 'Entrega completa',
-    observaciones: 'Sin observaciones',
+    detalle: 'Ventanales fachada principal',
+    observaciones: 'Instalación perfecta - cliente satisfecho',
   })
   await post(`${API_URL}/api/entregas`, {
-    cod_obra: 4,
+    cod_obra: 5,
     fecha_hora_entrega: '2025-09-25T09:30',
     estado: 'PENDIENTE',
-    detalle: 'Entrega adicional',
-    observaciones: 'Agregar manuales',
+    detalle: 'Puertas principales casas 1-20',
+    observaciones: 'Coordinar con paisajista para accesos',
   })
   await post(`${API_URL}/api/entregas`, {
-    cod_obra: 1,
+    cod_obra: 5,
     fecha_hora_entrega: '2025-09-28T11:00',
     estado: 'EN CURSO',
-    detalle: 'Entrega parcial',
-    observaciones: 'Cliente solicita cambio',
+    detalle: 'Ventanas casas 21-40',
+    observaciones: 'Modificación en color solicitada por cliente',
   })
   await post(`${API_URL}/api/entregas`, {
-    cod_obra: 2,
+    cod_obra: 6,
     fecha_hora_entrega: '2025-09-30T17:00',
     estado: 'ENTREGADO',
-    detalle: 'Entrega final',
-    observaciones: 'Entrega exitosa',
+    detalle: 'Cerramiento integral Torre A',
+    observaciones: 'Proyecto finalizado exitosamente',
   })
-
   // Visitas
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-06T10:00',
     cod_obra: 1,
     motivo_visita: 'MEDICION',
     estado: 'PROGRAMADA',
-    observaciones: 'Primera medición',
-    direccion_visita: 'Calle 1',
+    observaciones: 'Medición inicial para aberturas piso 1-3',
+    direccion_visita: 'Av. Pellegrini 1250, Rosario',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-07T11:30',
     cod_obra: 2,
     motivo_visita: 'RE-MEDICION',
     estado: 'EN CURSO',
-    observaciones: 'Ajuste de medidas',
-    direccion_visita: 'Calle 2',
+    observaciones: 'Ajuste medidas bloque B por modificación estructural',
+    direccion_visita: 'Av. San Martín 850, San Lorenzo',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-08T09:00',
     cod_obra: 3,
     motivo_visita: 'REPARACION',
     estado: 'COMPLETADA',
-    observaciones: 'Reparación de marco',
-    direccion_visita: 'Calle 3',
+    observaciones: 'Reparación marco puerta principal - resuelto',
+    direccion_visita: 'Bv. Gálvez 1680, Santa Fe',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-09T15:00',
     cod_obra: 4,
     motivo_visita: 'ASESORAMIENTO',
     estado: 'CANCELADA',
-    observaciones: 'Cliente canceló',
-    direccion_visita: 'Calle 4',
+    observaciones: 'Cliente reprogramó para próxima semana',
+    direccion_visita: 'Calle 7 entre 47 y 48, La Plata',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-10T13:00',
-    cod_obra: 1,
+    cod_obra: 2,
     motivo_visita: 'VISITA INICIAL',
     estado: 'REPROGRAMADA',
-    observaciones: 'Reprogramada por lluvia',
-    direccion_visita: 'Calle 1',
+    observaciones: 'Acceso complicado por lluvia - reagendar',
+    direccion_visita: 'Av. Colón 4500, Córdoba',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-11T14:30',
-    cod_obra: 2,
+    cod_obra: 6,
     motivo_visita: 'MEDICION',
     estado: 'PROGRAMADA',
-    observaciones: 'Medición adicional',
-    direccion_visita: 'Calle 2',
+    observaciones: 'Medición para cerramiento Torre A',
+    direccion_visita: 'Av. Aconquija 1200, San Miguel de Tucumán',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-12T16:00',
-    cod_obra: 3,
+    cod_obra: 1,
     motivo_visita: 'RE-MEDICION',
     estado: 'EN CURSO',
-    observaciones: 'Verificar cambios',
-    direccion_visita: 'Calle 3',
+    observaciones: 'Verificar cambios solicitados piso 4-6',
+    direccion_visita: 'Av. Pellegrini 1250, Rosario',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-13T12:00',
-    cod_obra: 4,
+    cod_obra: 2,
     motivo_visita: 'REPARACION',
     estado: 'COMPLETADA',
-    observaciones: 'Reparación finalizada',
-    direccion_visita: 'Calle 4',
+    observaciones: 'Ajuste marcos bloque A - trabajo finalizado',
+    direccion_visita: 'Av. San Martín 850, San Lorenzo',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-14T10:30',
-    cod_obra: 1,
+    cod_obra: 3,
     motivo_visita: 'ASESORAMIENTO',
     estado: 'CANCELADA',
-    observaciones: 'Cliente no disponible',
-    direccion_visita: 'Calle 1',
+    observaciones: 'Arquitecto no disponible - reprogramar',
+    direccion_visita: 'Bv. Gálvez 1680, Santa Fe',
   })
   await post(`${API_URL}/api/visitas`, {
     fecha_hora_visita: '2025-09-15T09:30',
-    cod_obra: 2,
+    cod_obra: 4,
     motivo_visita: 'VISITA INICIAL',
     estado: 'REPROGRAMADA',
-    observaciones: 'Reprogramada por feriado',
-    direccion_visita: 'Calle 2',
+    observaciones: 'Feriado local - nueva fecha coordinada',
+    direccion_visita: 'Calle 7 entre 47 y 48, La Plata',
   })
 
   // Órdenes de Producción
@@ -331,61 +368,49 @@ async function seed() {
     cod_obra: 1,
     fecha_confeccion: '2025-09-05',
     fecha_validacion: '2025-09-06',
-    url: 'https://docs.luhmann.com/op1.pdf',
+    url: 'https://docs.sigma-la.com/op-rosario-pellegrini-001.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
     cod_obra: 1,
     fecha_confeccion: '2025-09-10',
     fecha_validacion: '2025-09-11',
-    url: 'https://docs.luhmann.com/op2.pdf',
+    url: 'https://docs.sigma-la.com/op-rosario-pellegrini-002.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
     cod_obra: 2,
     fecha_confeccion: '2025-09-12',
     fecha_validacion: '2025-09-13',
-    url: 'https://docs.luhmann.com/op3.pdf',
+    url: 'https://docs.sigma-la.com/op-sanlorenzo-sanmartin-001.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 2,
+    cod_obra: 3,
     fecha_confeccion: '2025-09-15',
     fecha_validacion: '2025-09-16',
-    url: 'https://docs.luhmann.com/op4.pdf',
+    url: 'https://docs.sigma-la.com/op-santafe-galvez-001.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 3,
+    cod_obra: 4,
     fecha_confeccion: '2025-09-18',
     fecha_validacion: '2025-09-19',
-    url: 'https://docs.luhmann.com/op5.pdf',
+    url: 'https://docs.sigma-la.com/op-laplata-calle7-001.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 3,
+    cod_obra: 5,
     fecha_confeccion: '2025-09-20',
     fecha_validacion: '2025-09-21',
-    url: 'https://docs.luhmann.com/op6.pdf',
+    url: 'https://docs.sigma-la.com/op-cordoba-colon-001.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 4,
+    cod_obra: 5,
     fecha_confeccion: '2025-09-22',
     fecha_validacion: '2025-09-23',
-    url: 'https://docs.luhmann.com/op7.pdf',
+    url: 'https://docs.sigma-la.com/op-cordoba-colon-002.pdf',
   })
   await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 4,
+    cod_obra: 6,
     fecha_confeccion: '2025-09-25',
     fecha_validacion: '2025-09-26',
-    url: 'https://docs.luhmann.com/op8.pdf',
-  })
-  await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 1,
-    fecha_confeccion: '2025-09-28',
-    fecha_validacion: '2025-09-29',
-    url: 'https://docs.luhmann.com/op9.pdf',
-  })
-  await post(`${API_URL}/api/ordenes-produccion`, {
-    cod_obra: 2,
-    fecha_confeccion: '2025-09-30',
-    fecha_validacion: '2025-10-01',
-    url: 'https://docs.luhmann.com/op10.pdf',
+    url: 'https://docs.sigma-la.com/op-tucuman-aconquija-001.pdf',
   })
   const relacionesVisitaEmpleado = [
     { cuil: '20999999992', cod_visita: 1 },

--- a/src/shared/db/seeder.ts
+++ b/src/shared/db/seeder.ts
@@ -20,8 +20,8 @@ async function seed() {
     nombre_localidad: 'Ciudad Uno',
   })
   await post(`${API_URL}/api/localidades`, {
-    cod_postal: 2000,
-    nombre_localidad: 'Ciudad Dos',
+    cod_postal: 2200,
+    nombre_localidad: 'San Lorenzo',
   })
   await post(`${API_URL}/api/localidades`, {
     cod_postal: 3000,
@@ -146,7 +146,7 @@ async function seed() {
   })
   await post(`${API_URL}/api/obras`, {
     cod_obra: 2,
-    cod_postal: 2000,
+    cod_postal: 2200,
     cuil: '20222222222',
     fecha_ini: '2025-09-02',
     estado: 'ACTIVA',
@@ -387,6 +387,40 @@ async function seed() {
     fecha_validacion: '2025-10-01',
     url: 'https://docs.luhmann.com/op10.pdf',
   })
+  const relacionesVisitaEmpleado = [
+    { cuil: '20999999992', cod_visita: 1 },
+    { cuil: '20999999910', cod_visita: 1 },
+
+    { cuil: '20999999992', cod_visita: 2 },
+    { cuil: '20999999911', cod_visita: 2 },
+
+    { cuil: '20999999912', cod_visita: 3 },
+    { cuil: '20999999913', cod_visita: 3 },
+
+    { cuil: '20999999992', cod_visita: 4 },
+
+    { cuil: '20999999910', cod_visita: 5 },
+    { cuil: '20999999914', cod_visita: 5 },
+
+    { cuil: '20999999992', cod_visita: 6 },
+    { cuil: '20999999911', cod_visita: 6 },
+
+    { cuil: '20999999913', cod_visita: 7 },
+    { cuil: '20999999912', cod_visita: 7 },
+
+    { cuil: '20999999914', cod_visita: 8 },
+    { cuil: '20999999910', cod_visita: 8 },
+
+    { cuil: '20999999992', cod_visita: 9 },
+
+    { cuil: '20999999911', cod_visita: 10 },
+    { cuil: '20999999913', cod_visita: 10 },
+  ]
+
+  // Crear relaciones empleado-visita
+  for (const relacion of relacionesVisitaEmpleado) {
+    await post(`${API_URL}/api/empleado-visita`, relacion)
+  }
 
   // Relaciones Empleado-Entrega
   const relacionesEntregaEmpleado = [

--- a/src/shared/routes/index.routes.ts
+++ b/src/shared/routes/index.routes.ts
@@ -47,6 +47,7 @@ import presupuestoRouter from '../../models/Presupuesto/presupuesto.routes.js'
 import usoMaquinariaRouter from '../../models/UsoMaquinaria/usoMaquinaria.routes.js'
 import visitaRouter from '../../models/Visita/visita.routes.js'
 import entregaEmpleadoRouter from '../../models/EntregaEmpleado/entregaEmpleado.routes.js'
+import visitaEmpleadoRouter from '../../models/VisitaEmpleado/visitaEmpleado.routes.js'
 
 import authRouter from '../../models/Auth/auth.routes.js'
 import routeMid from '../../models/midlewareTest/mid.routes.js'
@@ -70,6 +71,7 @@ router.use('/api/uso-maquinaria', usoMaquinariaRouter)
 router.use('/api/presupuestos', presupuestoRouter)
 router.use('/api/visitas', visitaRouter)
 router.use('/api/entrega-empleado', entregaEmpleadoRouter)
+router.use('/api/empleado-visita', visitaEmpleadoRouter)
 
 router.use((req, res) => {
   res.status(404).json({


### PR DESCRIPTION

### Resumen
Este PR agrega los campos **teléfono** y **mail** del cliente al **repositorio de entregas**, permitiendo disponer de información de contacto directamente desde las consultas relacionadas con entregas.

---

### Cambios Técnicos Implementados
- **Repositorio de Entrega:**  
  Se añadieron los campos `telefono` y `mail` al modelo de selección de cliente dentro del `entrega.repository.ts`.
- **Datos Enriquecidos:**  
  Ahora las respuestas de las entregas incluyen los datos de contacto del cliente asociados.
