### PR TITLE
feat: Add endpoints to finalize and cancel visits

### DIFF
--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -95,6 +95,32 @@ export class VisitaController {
       })
     }
   }
+
+  async finalizarVisita(req: Request, res: Response) {
+    try {
+      const { id } = req.params
+      const { observaciones } = req.body
+      const visita = await visitaService.finalizar(Number(id), observaciones)
+      res.json(visita)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Error desconocido'
+      res.status(404).json({ error: message })
+    }
+  }
+
+  async cancelarVisita(req: Request, res: Response) {
+    try {
+      const { id } = req.params
+      const { motivo } = req.body
+      const visita = await visitaService.cancelar(Number(id), motivo)
+      res.json(visita)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Error desconocido'
+      res.status(404).json({ error: message })
+    }
+  }
 }
 
 export const visitaController = new VisitaController()

--- a/src/models/Visita/visita.routes.ts
+++ b/src/models/Visita/visita.routes.ts
@@ -55,4 +55,12 @@ visitaRouter.get('/obra/:cod_obra', (req, res) => {
   visitaController.getVisitasByObra(req, res)
 })
 
+visitaRouter.patch('/:id/finalizar', (req, res) => {
+  visitaController.finalizarVisita(req, res)
+})
+
+visitaRouter.patch('/:id/cancelar', (req, res) => {
+  visitaController.cancelarVisita(req, res)
+})
+
 export default visitaRouter

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -167,6 +167,55 @@ export class VisitaService {
   async getVisitasByObra(cod_obra: number): Promise<visita[]> {
     return await this.visitaRepository.findByObra(cod_obra)
   }
+
+  /**
+   * Finaliza una visita, cambiando su estado a 'COMPLETADA'.
+   * Opcionalmente, actualiza las observaciones (para registrar medidas).
+   * @param {number} cod_visita - El código de la visita a finalizar.
+   * @param {string} [observaciones] - Las observaciones o medidas registradas.
+   * @returns {Promise<visita>} - La visita actualizada.
+   */
+  async finalizar(cod_visita: number, observaciones?: string): Promise<visita> {
+    const existingVisita = await this.visitaRepository.findById(cod_visita)
+    if (!existingVisita) {
+      throw new Error('Visita no encontrada')
+    }
+
+    const updateData: Prisma.visitaUpdateInput = {
+      estado: 'COMPLETADA',
+    }
+
+    if (observaciones) {
+      updateData.observaciones = observaciones
+    }
+
+    return await this.visitaRepository.update(cod_visita, updateData)
+  }
+
+  /**
+   * Cancela una visita, cambiando su estado a 'CANCELADA'.
+   * Registra la fecha de cancelación y actualiza las observaciones con el motivo.
+   * @param {number} cod_visita - El código de la visita a cancelar.
+   * @param {string} [motivo] - El motivo de la cancelación.
+   * @returns {Promise<visita>} - La visita actualizada.
+   */
+  async cancelar(cod_visita: number, motivo?: string): Promise<visita> {
+    const existingVisita = await this.visitaRepository.findById(cod_visita)
+    if (!existingVisita) {
+      throw new Error('Visita no encontrada')
+    }
+
+    const updateData: Prisma.visitaUpdateInput = {
+      estado: 'CANCELADA',
+      fecha_cancelacion: new Date(),
+    }
+
+    if (motivo) {
+      updateData.observaciones = `Visita cancelada: ${motivo}`
+    }
+
+    return await this.visitaRepository.update(cod_visita, updateData)
+  }
 }
 
 export const visitaService = new VisitaService()


### PR DESCRIPTION
### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
Ejemplo: "Este PR refactoriza el módulo `student` para alinearlo con la arquitectura moderna del proyecto."
-->
Este PR introduce los endpoints y la lógica de negocio en el backend para gestionar la finalización o cancelación de una visita, cumpliendo con los requisitos del **CUU 05 - Registrar Medidas**.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
- **Validación:** Se ha añadido validación de entrada para `x` usando `y`.
- **Refactorización del Controlador:** Se ha aislado la lógica de negocio en el servicio, asegurando el uso de `await`.
- **Seguridad:** Se ha aplicado el `authMiddleware` a las nuevas rutas.
-->
- **Servicio (`visita.service.ts`):** Se añadieron dos nuevos métodos:
  - `finalizar(cod_visita, observaciones)`: Cambia el estado de la visita a `COMPLETADA` y actualiza las observaciones con las medidas registradas.
  - `cancelar(cod_visita, motivo)`: Cambia el estado a `CANCELADA`, establece la `fecha_cancelacion` y guarda el motivo en las observaciones.

- **Controlador (`visita.controller.ts`):** Se crearon los métodos `finalizarVisita` y `cancelarVisita` para manejar las peticiones HTTP y llamar a los nuevos servicios correspondientes.

- **Rutas (`visita.routes.ts`):** Se expusieron dos nuevos endpoints utilizando el método `PATCH` para reflejar la actualización parcial del recurso:
  - `PATCH /api/visitas/:id/finalizar`: Para marcar una visita como completada.
  - `PATCH /api/visitas/:id/cancelar`: Para marcar una visita como cancelada.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
1.  Iniciar el servidor.
2.  Obtener un token JWT válido.
3.  Probar el endpoint `GET /api/...` con un token válido.
4.  **Verificar Fallos:** Intentar acceder al mismo endpoint sin token (esperado: 401 Unauthorized).
-->
1.  Iniciar el servidor de backend (`pnpm run start:dev`).
2.  Obtener un token JWT válido de un usuario con rol `VISITADOR` a través del endpoint `POST /api/auth/login`.
3.  Asegurarse de tener una visita en la base de datos con estado `PROGRAMADA`. Obtener su `cod_visita`.

4.  **Prueba de Éxito (Finalizar Visita):**
    -   Realizar una petición `PATCH` a `/api/visitas/[COD_VISITA]/finalizar`.
    -   Incluir en el body un JSON con las medidas: `{ "observaciones": "Medidas: Ancho 2.5m, Alto 1.8m. Todo correcto." }`
    -   **Verificar:** La respuesta debe ser `200 OK` con los datos de la visita actualizada. En la base de datos, el `estado` debe ser `COMPLETADA` y el campo `observaciones` debe contener el texto enviado.

5.  **Prueba de Camino Alternativo (Cancelar Visita):**
    -   Tomar otra visita con estado `PROGRAMADA`.
    -   Realizar una petición `PATCH` a `/api/visitas/[COD_VISITA]/cancelar`.
    -   Incluir en el body un JSON con el motivo: `{ "motivo": "El cliente no se encontraba en el domicilio." }`
    -   **Verificar:** La respuesta debe ser `200 OK`. En la base de datos, el `estado` debe ser `CANCELADA`, el campo `fecha_cancelacion` debe tener la fecha actual y `observaciones` debe contener el motivo.