### PR TITLE
feat: add new endpoints in ordenes de produccion module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,7 +44,9 @@ model entrega {
   cod_entrega          Int                    @id @default(autoincrement())
   dias_viaticos        Int?
   fecha_cancelacion    DateTime?              @db.Date
+  cod_op               Int?                   @unique
   obra                 obra                   @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  orden_de_produccion  orden_de_produccion?   @relation(fields: [cod_op], references: [cod_op])
   entrega_empleado     entrega_empleado[]
   uso_maquinaria       uso_maquinaria[]
   uso_vehiculo_entrega uso_vehiculo_entrega[]
@@ -106,6 +108,7 @@ model orden_de_produccion {
   cod_op           Int       @id @default(autoincrement())
   public_id        String?   @db.VarChar(255)
   estado           String    @default("PENDIENTE") @db.VarChar(255)
+  entrega          entrega?
   obra             obra      @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
 }
 

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -5,114 +5,227 @@ const ordenService = new OrdenProduccionService()
 
 export class OrdenProduccionController {
   async create(req: Request, res: Response) {
-  try {
-    const { cod_obra } = req.body
-    const file = req.file
+    try {
+      const { cod_obra } = req.body
+      const file = req.file
 
-    if (!file) {
-      return res.status(400).json({ message: 'No se envió ningún archivo' })
+      if (!file) {
+        return res.status(400).json({ message: 'No se envió ningún archivo' })
+      }
+
+      const nueva = await ordenService.create({
+        cod_obra: parseInt(cod_obra),
+        url: file.path,
+        public_id: file.filename,
+      })
+
+      res.status(201).json(nueva)
+    } catch (error) {
+      console.error('Error al crear orden:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al crear orden de producción',
+      })
     }
-
-    const nueva = await ordenService.create({
-      cod_obra: parseInt(cod_obra),
-      url: file.path,
-      public_id: file.filename,
-    })
-
-    res.status(201).json(nueva)
-  } catch (error) {
-    console.error('Error al crear orden:', error)
-    res.status(500).json({ 
-      message: error instanceof Error ? error.message : 'Error al crear orden de producción' 
-    })
   }
-}
 
   async getAll(req: Request, res: Response) {
-    const ordenes = await ordenService.findAll()
-    res.status(200).json(ordenes)
+    try {
+      const ordenes = await ordenService.findAll()
+      res.status(200).json(ordenes)
+    } catch (error) {
+      console.error('Error al obtener órdenes:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al obtener órdenes de producción',
+      })
+    }
   }
 
   async getOne(req: Request, res: Response) {
-    const cod_orden = parseInt(req.params.cod_orden, 10)
-    const orden = await ordenService.findById(cod_orden)
-    if (!orden) {
-      return res.status(404).json({ message: 'Orden de producción no encontrada' })
+    try {
+      const cod_orden = parseInt(req.params.cod_orden, 10)
+
+      if (isNaN(cod_orden)) {
+        return res.status(400).json({ message: 'Código de orden inválido' })
+      }
+
+      const orden = await ordenService.findById(cod_orden)
+      if (!orden) {
+        return res
+          .status(404)
+          .json({ message: 'Orden de producción no encontrada' })
+      }
+      res.status(200).json(orden)
+    } catch (error) {
+      console.error('Error al obtener orden:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al obtener orden de producción',
+      })
     }
-    res.json(orden)
   }
 
   async update(req: Request, res: Response) {
-    const cod_orden = parseInt(req.params.cod_orden, 10)
-    const orden = await ordenService.update(cod_orden, req.body)
-    res.json(orden)
+    try {
+      const cod_orden = parseInt(req.params.cod_orden, 10)
+
+      if (isNaN(cod_orden)) {
+        return res.status(400).json({ message: 'Código de orden inválido' })
+      }
+
+      // Verificar que la orden existe
+      const ordenExistente = await ordenService.findById(cod_orden)
+      if (!ordenExistente) {
+        return res
+          .status(404)
+          .json({ message: 'Orden de producción no encontrada' })
+      }
+
+      const orden = await ordenService.update(cod_orden, req.body)
+      res.status(200).json(orden)
+    } catch (error) {
+      console.error('Error al actualizar orden:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al actualizar orden de producción',
+      })
+    }
   }
 
   async remove(req: Request, res: Response) {
-    const cod_orden = parseInt(req.params.cod_orden, 10)
-    const orden = await ordenService.remove(cod_orden)
-    res.json(orden)
+    try {
+      const cod_orden = parseInt(req.params.cod_orden, 10)
 
-  }
-    async getValidadas(req: Request, res: Response) {
-  const ordenes = await ordenService.findValidadas()
-  res.json(ordenes)
-}
+      if (isNaN(cod_orden)) {
+        return res.status(400).json({ message: 'Código de orden inválido' })
+      }
 
-async getEnProduccion(req: Request, res: Response) {
-  const ordenes = await ordenService.findEnProduccion()
-  res.json(ordenes)
-}
+      const orden = await ordenService.remove(cod_orden)
+      res.status(200).json(orden)
+    } catch (error) {
+      console.error('Error al eliminar orden:', error)
 
-async iniciarProduccion(req: Request, res: Response) {
-  try {
-    const cod_op = parseInt(req.params.cod_op, 10)
-    
-    const orden = await ordenService.findById(cod_op)
-    if (!orden) {
-      return res.status(404).json({ message: 'Orden de producción no encontrada' })
+      if (
+        error instanceof Error &&
+        error.message.includes('No existe una orden')
+      ) {
+        return res.status(404).json({ message: error.message })
+      }
+
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al eliminar orden de producción',
+      })
     }
-
-    await ordenService.update(cod_op, {
-      estado: 'EN PRODUCCION',
-    })
-
-    const { ObraService } = await import('../Obra/obra.service.js')
-    const obraService = new ObraService()
-    
-    await obraService.update(orden.cod_obra, {
-      estado: 'EN PRODUCCION',
-    })
-
-    res.json({ message: 'Producción iniciada correctamente' })
-  } catch (error) {
-    console.error('Error al iniciar producción:', error)
-    res.status(500).json({ message: 'Error al iniciar producción' })
   }
-}
-
-async finalizarProduccion(req: Request, res: Response) {
-  try {
-    const cod_op = parseInt(req.params.cod_op, 10)
-    
-    const orden = await ordenService.findById(cod_op)
-    if (!orden) {
-      return res.status(404).json({ message: 'Orden de producción no encontrada' })
+  async getValidadas(req: Request, res: Response) {
+    try {
+      const ordenes = await ordenService.findValidadas()
+      res.status(200).json(ordenes)
+    } catch (error) {
+      console.error('Error al obtener órdenes validadas:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al obtener órdenes validadas',
+      })
     }
-
-    await ordenService.finalizarProduccion(cod_op)
-
-    res.json({ message: 'Producción finalizada correctamente' })
-  } catch (error) {
-    console.error('Error al finalizar producción:', error)
-    res.status(500).json({ message: 'Error al finalizar producción' })
   }
-}
 
-async getByObra(req: Request, res: Response) {
-  const cod_obra = parseInt(req.params.cod_obra, 10)
-  const ordenes = await ordenService.findByObra(cod_obra)
-  res.json(ordenes)
-}
+  async getEnProduccion(req: Request, res: Response) {
+    try {
+      const ordenes = await ordenService.findEnProduccion()
+      res.status(200).json(ordenes)
+    } catch (error) {
+      console.error('Error al obtener órdenes en producción:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al obtener órdenes en producción',
+      })
+    }
+  }
 
+  async iniciarProduccion(req: Request, res: Response) {
+    try {
+      const cod_op = parseInt(req.params.cod_op, 10)
+
+      const orden = await ordenService.findById(cod_op)
+      if (!orden) {
+        return res
+          .status(404)
+          .json({ message: 'Orden de producción no encontrada' })
+      }
+
+      await ordenService.update(cod_op, {
+        estado: 'EN PRODUCCION',
+      })
+
+      const { ObraService } = await import('../Obra/obra.service.js')
+      const obraService = new ObraService()
+
+      await obraService.update(orden.cod_obra, {
+        estado: 'EN PRODUCCION',
+      })
+
+      res.json({ message: 'Producción iniciada correctamente' })
+    } catch (error) {
+      console.error('Error al iniciar producción:', error)
+      res.status(500).json({ message: 'Error al iniciar producción' })
+    }
+  }
+
+  async finalizarProduccion(req: Request, res: Response) {
+    try {
+      const cod_op = parseInt(req.params.cod_op, 10)
+
+      const orden = await ordenService.findById(cod_op)
+      if (!orden) {
+        return res
+          .status(404)
+          .json({ message: 'Orden de producción no encontrada' })
+      }
+
+      await ordenService.finalizarProduccion(cod_op)
+
+      res.json({ message: 'Producción finalizada correctamente' })
+    } catch (error) {
+      console.error('Error al finalizar producción:', error)
+      res.status(500).json({ message: 'Error al finalizar producción' })
+    }
+  }
+
+  async getByObra(req: Request, res: Response) {
+    try {
+      const cod_obra = parseInt(req.params.cod_obra, 10)
+
+      if (isNaN(cod_obra)) {
+        return res.status(400).json({ message: 'Código de obra inválido' })
+      }
+
+      const ordenes = await ordenService.findByObra(cod_obra)
+      res.status(200).json(ordenes)
+    } catch (error) {
+      console.error('Error al obtener órdenes por obra:', error)
+      res.status(500).json({
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Error al obtener órdenes por obra',
+      })
+    }
+  }
 }

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -19,55 +19,79 @@ export class OrdenProduccionRepository {
   async findAll(): Promise<orden_de_produccion[]> {
     return await this.prisma.orden_de_produccion.findMany({
       orderBy: { fecha_confeccion: 'desc' },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
+        },
+      },
     })
   }
 
   async findById(cod_op: number): Promise<orden_de_produccion | null> {
     return await this.prisma.orden_de_produccion.findUnique({
       where: { cod_op },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
+        },
+      },
     })
   }
 
-async findValidadas(): Promise<orden_de_produccion[]> {
-  return await this.prisma.orden_de_produccion.findMany({
-    where: {
-      estado: 'APROBADA',
-    },
-    orderBy: { fecha_validacion: 'desc' },
-    include: {
-      obra: {
-        include: {
-          cliente: true,
-          localidad: true,
+  async findValidadas(): Promise<orden_de_produccion[]> {
+    return await this.prisma.orden_de_produccion.findMany({
+      where: {
+        estado: 'APROBADA',
+      },
+      orderBy: { fecha_validacion: 'desc' },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
         },
       },
-    },
-  })
-}
+    })
+  }
 
-async findEnProduccion(): Promise<orden_de_produccion[]> {
-  return await this.prisma.orden_de_produccion.findMany({
-    where: {
-      estado: 'EN PRODUCCION',
-    },
-    orderBy: { fecha_validacion: 'desc' },
-    include: {
-      obra: {
-        include: {
-          cliente: true,
-          localidad: true,
+  async findEnProduccion(): Promise<orden_de_produccion[]> {
+    return await this.prisma.orden_de_produccion.findMany({
+      where: {
+        estado: 'EN PRODUCCION',
+      },
+      orderBy: { fecha_validacion: 'desc' },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
         },
       },
-    },
-  })
-}
+    })
+  }
 
-async findByObra(cod_obra: number): Promise<orden_de_produccion[]> {
-  return await this.prisma.orden_de_produccion.findMany({
-    where: { cod_obra },
-    orderBy: { fecha_confeccion: 'desc' },
-  })
-}
+  async findByObra(cod_obra: number): Promise<orden_de_produccion[]> {
+    return await this.prisma.orden_de_produccion.findMany({
+      where: { cod_obra },
+      orderBy: { fecha_confeccion: 'desc' },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
+        },
+      },
+    })
+  }
 
   async update(
     cod_op: number,
@@ -76,6 +100,14 @@ async findByObra(cod_obra: number): Promise<orden_de_produccion[]> {
     return await this.prisma.orden_de_produccion.update({
       where: { cod_op },
       data,
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+            localidad: true,
+          },
+        },
+      },
     })
   }
 


### PR DESCRIPTION
### Issue Relacionada
No hay issue

---

### Resumen
Se mejora el módulo de Órdenes de Producción para incluir relaciones completas (obra → cliente, localidad) en las respuestas, se refuerza el manejo de errores y se garantiza que el endpoint de aprobación (PUT) devuelva la orden actualizada con todas sus relaciones.

### Cambios Técnicos Implementados
- Repository: `findAll`, `findById`, `findByObra`, `update` ahora incluyen `obra { cliente, localidad }`.
- Controller: validación de parámetros numéricos, try/catch en todos los métodos, códigos HTTP adecuados (200, 201, 400, 404, 500), verificación de existencia antes de update/delete.
- Routes: confirmadas y sin cambios funcionales; montadas en `/api/ordenes-produccion`.

---

### Guía para Pruebas y Revisión
1. Iniciar el servidor.
2. GET `/api/ordenes-produccion/` — verificar que cada orden incluya `obra.cliente` y `obra.localidad`.
3. PUT `/api/ordenes-produccion/:cod_orden` con body:
```json
{
  "estado": "APROBADA",
  "fecha_validacion": "2025-10-06T15:30:00.000Z"
}