### PR TITLE
feat: Automatically set obra status to finalizada when production ends

### DIFF
--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -1,5 +1,6 @@
 import { orden_de_produccion, Prisma } from '@prisma/client'
 import { OrdenProduccionRepository } from './ordenProduccion.repository.js'
+import { prisma } from '../../shared/db/prismaClient.js'
 
 export class OrdenProduccionService {
   private repository: OrdenProduccionRepository
@@ -16,7 +17,7 @@ export class OrdenProduccionService {
   }): Promise<orden_de_produccion> {
     const prismaData: Prisma.orden_de_produccionCreateInput = {
       obra: {
-        connect: { cod_obra: data.cod_obra }
+        connect: { cod_obra: data.cod_obra },
       },
       fecha_confeccion: new Date(),
       fecha_validacion: data.fecha_validacion || null,
@@ -36,12 +37,12 @@ export class OrdenProduccionService {
   }
 
   async findValidadas(): Promise<orden_de_produccion[]> {
-  return await this.repository.findValidadas()
-}
+    return await this.repository.findValidadas()
+  }
 
-async findEnProduccion(): Promise<orden_de_produccion[]> {
-  return await this.repository.findEnProduccion()
-}
+  async findEnProduccion(): Promise<orden_de_produccion[]> {
+    return await this.repository.findEnProduccion()
+  }
 
   async update(
     cod_op: number,
@@ -53,19 +54,43 @@ async findEnProduccion(): Promise<orden_de_produccion[]> {
   async remove(cod_op: number): Promise<orden_de_produccion> {
     const existingOrden = await this.repository.findById(cod_op)
     if (!existingOrden) {
-      throw new Error('No existe una orden de producción con el código proporcionado.')
+      throw new Error(
+        'No existe una orden de producción con el código proporcionado.',
+      )
     }
     return await this.repository.delete(cod_op)
   }
 
   async findByObra(cod_obra: number): Promise<orden_de_produccion[]> {
-  return await this.repository.findByObra(cod_obra)
-}
+    return await this.repository.findByObra(cod_obra)
+  }
 
-async finalizarProduccion(cod_op: number): Promise<orden_de_produccion> {
-  return await this.repository.update(cod_op, {
-    estado: 'FINALIZADA',
-  })
-}
-}
+  async finalizarProduccion(cod_op: number): Promise<orden_de_produccion> {
+    const orden = await this.repository.findById(cod_op)
+    if (!orden) {
+      throw new Error('Orden de producción no encontrada.')
+    }
+    if (orden.estado !== 'EN PRODUCCION') {
+      throw new Error(
+        'Solo se pueden finalizar órdenes que están "En Producción".',
+      )
+    }
+    const [ordenActualizada] = await prisma.$transaction([
+      prisma.orden_de_produccion.update({
+        where: { cod_op },
+        data: { estado: 'FINALIZADA' },
+      }),
 
+      prisma.obra.update({
+        where: { cod_obra: orden.cod_obra },
+        data: { estado: 'FINALIZADA' },
+      }),
+    ])
+
+    console.log(
+      `[NOTIFICACIÓN] La producción de la Obra #${orden.cod_obra} ha finalizado. Notificar a Coordinación.`,
+    )
+
+    return ordenActualizada
+  }
+}


### PR DESCRIPTION
### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
Ejemplo: "Este PR refactoriza el módulo `student` para alinearlo con la arquitectura moderna del proyecto."
-->
Este PR corrige y completa el flujo del **CUU 08 - Actualizar Estado Obra**, asegurando que al finalizar una orden de producción, el estado de la obra asociada también se actualice a "Finalizada".

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
- **Validación:** Se ha añadido validación de entrada para `x` usando `y`.
- **Refactorización del Controlador:** Se ha aislado la lógica de negocio en el servicio, asegurando el uso de `await`.
- **Seguridad:** Se ha aplicado el `authMiddleware` a las nuevas rutas.
-->
- **Refactorización del Servicio (`ordenProduccion.service.ts`):**
  - Se modificó el método `finalizarProduccion` para utilizar una **transacción de Prisma (`$transaction`)**.
  - Ahora, además de actualizar el estado de la `orden_de_produccion` a `FINALIZADA`, también se actualiza el estado de la `obra` asociada a `FINALIZADA` en la misma operación atómica.
  - Se añadió una validación para asegurar que solo las órdenes en estado `EN PRODUCCION` puedan ser finalizadas.
  - Se incluyó un `console.log` para simular la notificación a Coordinación, tal como lo especifica el caso de uso.

- **No se realizaron cambios** en controladores o rutas, ya que el endpoint existente (`POST /api/ordenes-produccion/:cod_op/finalizar`) fue reutilizado.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
1.  Iniciar el servidor.
2.  Obtener un token JWT válido.
3.  Probar el endpoint `GET /api/...` con un token válido.
4.  **Verificar Fallos:** Intentar acceder al mismo endpoint sin token (esperado: 401 Unauthorized).
-->
1.  Iniciar el servidor de backend (`pnpm run start:dev`).
2.  Asegurarse de tener una `obra` en estado `EN PRODUCCION` y una `orden_de_produccion` asociada, también en estado `EN PRODUCCION`.
3.  Obtener el `cod_op` de dicha orden de producción.
4.  Realizar una petición `POST` al endpoint `/api/ordenes-produccion/[COD_OP]/finalizar`.

5.  **Verificación de Éxito:**
    -   La respuesta debe ser `200 OK` y devolver la orden de producción actualizada.
    -   En la consola del backend, se debe observar el mensaje de notificación: `[NOTIFICACIÓN] La producción de la Obra #[NÚMERO_DE_OBRA] ha finalizado...`.
    -   **En la base de datos (usando Prisma Studio):**
        -   Verificar que la `orden_de_produccion` con el `cod_op` utilizado ahora tenga su `estado` en `FINALIZADA`.
        -   Verificar que la `obra` asociada a esa orden ahora tenga su `estado` en `FINALIZADA`.

6.  **Prueba de Fallo:**
    -   Intentar realizar la misma petición `POST` de nuevo sobre la misma orden (que ahora está `FINALIZADA`).
    -   **Verificar:** La respuesta debe ser un error `400 Bad Request` con el mensaje: "Solo se pueden finalizar órdenes que están "En Producción"".