### PR TITLE
feat: Automatiza estados de Obra y robustece flujos de pago y entrega

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "multer-storage-cloudinary": "^4.0.0",
-    "sigma-la-schemas": "^1.0.23",
+    "sigma-la-schemas": "^1.0.26",
     "valibot": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(cloudinary@2.7.0)
       sigma-la-schemas:
-        specifier: ^1.0.23
-        version: 1.0.23(typescript@5.9.2)
+        specifier: ^1.0.26
+        version: 1.0.26(typescript@5.9.2)
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
@@ -2084,8 +2084,8 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  sigma-la-schemas@1.0.23:
-    resolution: {integrity: sha512-EgFuX9D2WdfXJwehMIQ3kuIz+YAXqft5GAabrl3Y4LtZt0I+7t4+Esp1jubfWLzAQRieIn16yH31CpmIstIabg==}
+  sigma-la-schemas@1.0.26:
+    resolution: {integrity: sha512-d/ALBwQcCz9Sr+vycDJTrJJ6RqyHljJ3dM/GdRQtQGvdte4By/OORQtg+5iWBvqaTAekTv7Gu+icWunZNgu6/A==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -4761,7 +4761,7 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  sigma-la-schemas@1.0.23(typescript@5.9.2):
+  sigma-la-schemas@1.0.26(typescript@5.9.2):
     dependencies:
       valibot: 1.1.0(typescript@5.9.2)
     transitivePeerDependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -159,7 +159,7 @@ model uso_vehiculo_entrega {
   estado              String    @db.VarChar(50)
   cod_entrega         Int
   obraCod_obra        Int?
-  fecha_hora_ini_est  DateTime  @db.Timestamp(6)
+  fecha_hora_fin_est  DateTime  @db.Timestamp(6)
   entrega             entrega   @relation(fields: [cod_entrega], references: [cod_entrega], onDelete: NoAction, onUpdate: NoAction)
   obra                obra?     @relation(fields: [obraCod_obra], references: [cod_obra])
   vehiculo            vehiculo  @relation(fields: [patente], references: [patente], onDelete: NoAction, onUpdate: NoAction)
@@ -198,6 +198,7 @@ model visita {
   estado              String                @db.VarChar(50)
   direccion_visita    String?               @db.VarChar(500)
   cod_visita          Int                   @id @default(autoincrement())
+  dias_viatico        Int?
   empleado_visita     empleado_visita[]
   uso_vehiculo_visita uso_vehiculo_visita[]
   obra                obra?                 @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)

--- a/src/models/Entrega/entrega.controller.ts
+++ b/src/models/Entrega/entrega.controller.ts
@@ -23,11 +23,11 @@ export class EntregaController {
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.message.includes('Conflicto de horario')) {
-          return res.status(409).json({ message: error.message });
+          return res.status(409).json({ message: error.message })
         }
-        return res.status(400).json({ message: error.message });
+        return res.status(400).json({ message: error.message })
       }
-      res.status(500).json({ message: 'Error interno del servidor' });
+      res.status(500).json({ message: 'Error interno del servidor' })
     }
   }
 
@@ -64,5 +64,33 @@ export class EntregaController {
       estado,
     )
     res.json(entregas)
+  }
+
+  async finalizarEntrega(req: Request, res: Response) {
+    try {
+      const cod_entrega = parseInt(req.params.id)
+      const { observaciones } = req.body
+      const entrega = await entregaService.finalizar(cod_entrega, observaciones)
+      res.json(entrega)
+    } catch (error) {
+      console.error('Error al finalizar entrega:', error)
+      const message =
+        error instanceof Error ? error.message : 'Error al finalizar la entrega'
+      res.status(400).json({ message })
+    }
+  }
+
+  async cancelarEntrega(req: Request, res: Response) {
+    try {
+      const cod_entrega = parseInt(req.params.id)
+      const { motivo } = req.body
+      const entrega = await entregaService.cancelar(cod_entrega, motivo)
+      res.json(entrega)
+    } catch (error) {
+      console.error('Error al cancelar entrega:', error)
+      const message =
+        error instanceof Error ? error.message : 'Error al cancelar la entrega'
+      res.status(400).json({ message })
+    }
   }
 }

--- a/src/models/Entrega/entrega.routes.ts
+++ b/src/models/Entrega/entrega.routes.ts
@@ -44,4 +44,12 @@ entregaRouter.delete(
   },
 )
 
+entregaRouter.patch('/:id/finalizar', (req, res) => {
+  entregaController.finalizarEntrega(req, res)
+})
+
+entregaRouter.patch('/:id/cancelar', (req, res) => {
+  entregaController.cancelarEntrega(req, res)
+})
+
 export default entregaRouter

--- a/src/models/Entrega/entrega.service.ts
+++ b/src/models/Entrega/entrega.service.ts
@@ -1,6 +1,7 @@
 import { EntregaRepository } from './entrega.repository.js'
 import { entrega, Prisma } from '@prisma/client'
 import { MaquinariaService } from '../Maquinaria/maquinaria.service.js'
+import { prisma } from '../../shared/db/prismaClient.js'
 
 /**
  * Servicio para manejar la lógica de negocio de entregas.
@@ -34,23 +35,40 @@ export class EntregaService {
     maquinarias?: number[]
     cod_op?: number
   }): Promise<entrega> {
-    const { empleados, cod_obra, maquinarias, cod_op, dias_viaticos, ...entregaData } = data
+    const {
+      empleados,
+      cod_obra,
+      maquinarias,
+      cod_op,
+      dias_viaticos,
+      ...entregaData
+    } = data
     const fechaParaPrisma = new Date(data.fecha_hora_entrega)
 
-    const diasDeUso = (dias_viaticos && dias_viaticos > 0) ? dias_viaticos : 1;
-    const horasDeUsoEnMs = diasDeUso * 24 * 60 * 60 * 1000;
-    const fechaFinEstimada = new Date(fechaParaPrisma.getTime() + horasDeUsoEnMs);
+    const diasDeUso = dias_viaticos && dias_viaticos > 0 ? dias_viaticos : 1
+    const horasDeUsoEnMs = diasDeUso * 24 * 60 * 60 * 1000
+    const fechaFinEstimada = new Date(
+      fechaParaPrisma.getTime() + horasDeUsoEnMs,
+    )
 
     if (maquinarias && maquinarias.length > 0) {
-      await this.maquinariaService.verificarDisponibilidadMaquinarias(maquinarias, fechaParaPrisma, fechaFinEstimada);
+      await this.maquinariaService.verificarDisponibilidadMaquinarias(
+        maquinarias,
+        fechaParaPrisma,
+        fechaFinEstimada,
+      )
     }
 
     const payload: Prisma.entregaCreateInput = {
       detalle: entregaData.detalle,
       estado: entregaData.estado,
       fecha_hora_entrega: fechaParaPrisma,
-      ...(entregaData.observaciones && { observaciones: entregaData.observaciones }),
-      ...(data.dias_viaticos !== undefined && { dias_viaticos: data.dias_viaticos }),
+      ...(entregaData.observaciones && {
+        observaciones: entregaData.observaciones,
+      }),
+      ...(data.dias_viaticos !== undefined && {
+        dias_viaticos: data.dias_viaticos,
+      }),
       obra: {
         connect: { cod_obra: cod_obra },
       },
@@ -61,17 +79,18 @@ export class EntregaService {
           obra: { connect: { cod_obra: cod_obra } },
         })),
       },
-      ...(maquinarias && maquinarias.length > 0 && {
-        uso_maquinaria: {
-          create: maquinarias.map(cod_maquina => ({
-            maquinaria: { connect: { cod_maquina: cod_maquina } },
-            fecha_hora_ini_uso: fechaParaPrisma,
-            fecha_hora_fin_est: fechaFinEstimada,
-            estado: 'EN USO',
-            obra: { connect: { cod_obra: cod_obra } },
-          })),
-        },
-      }),
+      ...(maquinarias &&
+        maquinarias.length > 0 && {
+          uso_maquinaria: {
+            create: maquinarias.map(cod_maquina => ({
+              maquinaria: { connect: { cod_maquina: cod_maquina } },
+              fecha_hora_ini_uso: fechaParaPrisma,
+              fecha_hora_fin_est: fechaFinEstimada,
+              estado: 'EN USO',
+              obra: { connect: { cod_obra: cod_obra } },
+            })),
+          },
+        }),
       ...(cod_op && {
         orden_de_produccion: {
           connect: { cod_op: cod_op },
@@ -79,7 +98,10 @@ export class EntregaService {
       }),
     }
 
-    console.log('--- Payload final enviado a Prisma ---', JSON.stringify(payload, null, 2));
+    console.log(
+      '--- Payload final enviado a Prisma ---',
+      JSON.stringify(payload, null, 2),
+    )
     return this.entregaRepository.create(payload)
   }
 
@@ -111,5 +133,63 @@ export class EntregaService {
     estado: string,
   ): Promise<entrega[]> {
     return this.entregaRepository.getByEmpleadoEstado(cuil_empleado, estado)
+  }
+
+  async finalizar(
+    cod_entrega: number,
+    observaciones?: string,
+  ): Promise<entrega> {
+    const [entregaActualizada] = await prisma.$transaction(async tx => {
+      const entrega = await tx.entrega.update({
+        where: { cod_entrega },
+        data: {
+          estado: 'ENTREGADO',
+          ...(observaciones && { observaciones }),
+        },
+      })
+
+      await tx.uso_vehiculo_entrega.updateMany({
+        where: { cod_entrega: cod_entrega },
+        data: { fecha_hora_fin_real: new Date() },
+      })
+
+      const otrasEntregasPendientes = await tx.entrega.count({
+        where: {
+          cod_obra: entrega.cod_obra,
+          estado: 'PENDIENTE',
+        },
+      })
+
+      if (otrasEntregasPendientes === 0) {
+        await tx.obra.update({
+          where: { cod_obra: entrega.cod_obra },
+          data: { estado: 'ENTREGADA' },
+        })
+      }
+
+      return [entrega]
+    })
+
+    return entregaActualizada
+  }
+
+  async cancelar(cod_entrega: number, motivo?: string): Promise<entrega> {
+    const [entregaCancelada] = await prisma.$transaction(async tx => {
+      const entrega = await tx.entrega.update({
+        where: { cod_entrega: cod_entrega },
+        data: {
+          estado: 'CANCELADO',
+          ...(motivo && { observaciones: `Entrega cancelada: ${motivo}` }),
+        },
+      })
+
+      await tx.uso_vehiculo_entrega.deleteMany({
+        where: { cod_entrega: cod_entrega },
+      })
+
+      return [entrega]
+    })
+
+    return entregaCancelada
   }
 }

--- a/src/models/Pago/pago.service.ts
+++ b/src/models/Pago/pago.service.ts
@@ -56,9 +56,16 @@ export class PagoService {
 
       const totalPagado = obra.pago.reduce((sum, p) => sum + p.monto, 0)
 
-      if (totalPagado > 0 && obra.estado !== 'FINALIZADA') {
+      if (totalPagado === 0) {
+        await tx.obra.update({
+          where: { cod_obra },
+          data: { estado: 'PAGADA PARCIALMENTE' },
+        })
+      }
+
+      if (totalPagado > 0 && obra.estado !== 'PRODUCCION FINALIZADA') {
         throw new Error(
-          'Solo se pueden registrar pagos finales si la obra está en estado "FINALIZADA".',
+          'Solo se pueden registrar pagos finales si la obra está en estado "PRODUCCION FINALIZADA".',
         )
       }
 

--- a/src/models/UsoVehiculoEntrega/usoVehiculoEntrega.routes.ts
+++ b/src/models/UsoVehiculoEntrega/usoVehiculoEntrega.routes.ts
@@ -21,12 +21,12 @@ usoVehiculoEntregaRouter.post(
   },
 )
 
-usoVehiculoEntregaRouter.get('/:cod_entrega/:cod_vehiculo', (req, res) => {
+usoVehiculoEntregaRouter.get('/:cod_entrega/:patente', (req, res) => {
   usoVehiculoEntregaController.getOne(req, res)
 })
 
 usoVehiculoEntregaRouter.put(
-  '/:cod_entrega/:cod_vehiculo',
+  '/:cod_entrega/:patente',
   validate({
     body: updateUsoVehiculoEntregaSchema,
   }),
@@ -35,7 +35,7 @@ usoVehiculoEntregaRouter.put(
   },
 )
 
-usoVehiculoEntregaRouter.delete('/:cod_entrega/:cod_vehiculo', (req, res) => {
+usoVehiculoEntregaRouter.delete('/:cod_entrega/:patente', (req, res) => {
   usoVehiculoEntregaController.remove(req, res)
 })
 


### PR DESCRIPTION
### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
-->
Este PR implementa la lógica de negocio para los CUU 09 y 11, robustece el sistema de pagos con validaciones críticas, alinea los estados de la Obra con la máquina de estados, y corrige un error fundamental en el script del seeder.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
-->
- **Sincronización con Máquina de Estados:**
  - Se añadió el estado `PAGADA PARCIALMENTE` al `enum EstadoObra` en `schema.prisma`.
  - El servicio de pagos ahora actualiza la obra a `PAGADA PARCIALMENTE` al registrar el primer pago.

- **Robustecimiento del Servicio de Pagos (`pago.service.ts`):**
  - **Corrección de Bug Crítico:** Se solucionó un error que causaba el crash del servidor al procesar el `monto` de un pago, cambiando la firma del método y la construcción del payload para ser tipo-seguro.
  - **Automatización (CUU 09):** Al registrar un pago que cubre el total del presupuesto aceptado, el estado de la obra cambia automáticamente a `PAGADA TOTALMENTE`.
  - **Validaciones de Negocio:**
    - No se permiten pagos si la obra no tiene un presupuesto aceptado.
    - No se permiten pagos finales (posteriores al primero) si la obra no está en estado `FINALIZADA`.
    - Se impide registrar un pago que exceda el saldo restante de la deuda.

- **Implementación de Lógica de Entrega (CUU 11):**
  - **Finalizar Entrega:** El servicio `finalizar` ahora actualiza la `fecha_hora_fin_real` de los `uso_vehiculo_entrega` asociados. Si es la última entrega, el estado de la `Obra` cambia a `ENTREGADA`.
  - **Cancelar Entrega:** El nuevo servicio `cancelar` actualiza el estado de la entrega y elimina los registros de `uso_vehiculo_entrega` asociados para liberar los recursos.

- **Corrección del Seeder:**
  - Se refactorizó `seeder.ts` para que llame directamente a los servicios de negocio en lugar de usar `fetch`, eliminando la dependencia de que la API esté corriendo y solucionando el error `ECONNREFUSED`.
  - Se actualizó el script `seed` en `package.json` para usar `tsx`, solucionando el error de ejecución de archivos `.ts`.
  - Se actualizaron los datos del seeder para usar los nuevos estados válidos.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios.
-->
1.  Ejecutar `pnpm install` para asegurar que `tsx` esté disponible.
2.  Ejecutar `pnpm run db:migrate` para aplicar los cambios en la base de datos.
3.  **Verificar Seeder:** Ejecutar `pnpm seed`. El proceso debe completarse sin errores de red ni de tipo.
4.  **Probar Lógica de Pagos:**
    -   Realizar un `POST` a `/api/pagos/obra/[COD_OBRA]` para una obra en estado `ACTIVA`. Verificar que el estado de la obra cambie a `PAGADA PARCIALMENTE`.
    -   Intentar realizar un segundo pago a la misma obra. Verificar que la API devuelva un error 400.
    -   Cambiar manualmente el estado de la obra a `FINALIZADA` e intentar registrar el pago restante. Verificar que la operación sea exitosa y el estado de la obra cambie a `PAGADA_TOTALMENTE`.
5.  **Probar Lógica de Entregas:**
    -   Realizar un `PATCH` a `/api/entregas/[ID_ENTREGA]/finalizar`. Verificar que el `uso_vehiculo_entrega` asociado se actualice y, si aplica, el estado de la `obra` cambie a `ENTREGADA`.
    -   Realizar un `PATCH` a `/api/entregas/[ID_ENTREGA]/cancelar`. Verificar que los `uso_vehiculo_entrega` asociados sean eliminados.