### PR TITLE
feat: add functionality to retrieve localidades by provincia and impl…

### DIFF
--- a/src/models/Localidad/localidad.controller.ts
+++ b/src/models/Localidad/localidad.controller.ts
@@ -19,6 +19,10 @@ export class LocalidadController {
     const localidad = await localidadService.create(req.body)
     res.status(201).json(localidad)
   }
+  async getByProvincia(provinciaId: number, req: Request, res: Response) {
+    const localidades = await localidadService.findByProvincia(provinciaId)
+    res.json(localidades)
+  }
 
   async getAll(req: Request, res: Response) {
     const localidades = await localidadService.findAll()

--- a/src/models/Localidad/localidad.repository.ts
+++ b/src/models/Localidad/localidad.repository.ts
@@ -13,6 +13,12 @@ export class LocalidadRepository {
       data,
     })
   }
+  async findByProvincia(cod_provincia: number): Promise<localidad[]> {
+    return await this.prisma.localidad.findMany({
+      where: { cod_provincia },
+      orderBy: { nombre_localidad: 'asc' },
+    })
+  }
 
   async findAll(): Promise<localidad[]> {
     return await this.prisma.localidad.findMany({

--- a/src/models/Localidad/localidad.routes.ts
+++ b/src/models/Localidad/localidad.routes.ts
@@ -6,6 +6,11 @@ import { updateLocalidadSchema, idParamsSchema } from 'sigma-la-schemas'
 const localidadController = new LocalidadController()
 const localidadRouter = Router()
 
+localidadRouter.get('/provincias/:provinciaId', (req, res) => {
+  const provinciaId = parseInt(req.params.provinciaId, 10)
+  localidadController.getByProvincia(provinciaId, req, res)
+})
+
 localidadRouter.get('/', (req, res) => {
   localidadController.getAll(req, res)
 })

--- a/src/models/Localidad/localidad.service.ts
+++ b/src/models/Localidad/localidad.service.ts
@@ -18,6 +18,9 @@ export class LocalidadService {
   constructor() {
     this.repository = new LocalidadRepository()
   }
+  async findByProvincia(cod_provincia: number): Promise<localidad[]> {
+    return await this.repository.findByProvincia(cod_provincia)
+  }
 
   async create(data: Prisma.localidadCreateInput): Promise<localidad> {
     return await this.repository.create(data)

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -19,6 +19,15 @@ export class ObraController {
     const nueva = await obraService.create(req.body)
     res.status(201).json(nueva)
   }
+  async buscar(req: Request, res: Response) {
+    try {
+      const q = req.query.q as string
+      const obras = await obraService.buscar(q)
+      res.json(obras)
+    } catch (error) {
+      res.status(500).json({ message: 'Error al buscar obras', error })
+    }
+  }
 
   async getAll(req: Request, res: Response) {
     const obras = await obraService.findAll()

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -86,6 +86,23 @@ export class ObraRepository {
       },
     })
   }
+  async buscar(q: string) {
+    return this.prisma.obra.findMany({
+      where: {
+        OR: [
+          { direccion: { contains: q, mode: 'insensitive' } },
+          { cliente: { razon_social: { contains: q, mode: 'insensitive' } } },
+          { cliente: { nombre: { contains: q, mode: 'insensitive' } } },
+          { cliente: { apellido: { contains: q, mode: 'insensitive' } } },
+        ],
+      },
+      include: {
+        cliente: true,
+      },
+      orderBy: { cod_obra: 'desc' },
+      take: 10,
+    })
+  }
 
   async findNotasConOrdenEnProceso(): Promise<obra[]> {
     return await this.prisma.obra.findMany({

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -10,6 +10,9 @@ import { updateObraSchema, idParamsSchema } from 'sigma-la-schemas'
 const obraController = new ObraController()
 const obraRouter = Router()
 
+obraRouter.get('/buscar', (req, res) => {
+  obraController.buscar(req, res)
+})
 obraRouter.get('/', (req, res) => {
   obraController.getAll(req, res)
 })

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -18,6 +18,9 @@ export class ObraService {
   constructor() {
     this.repository = new ObraRepository()
   }
+  async buscar(q: string) {
+    return this.repository.buscar(q)
+  }
 
   async create(data: Prisma.obraCreateInput): Promise<obra> {
     if (

--- a/src/models/Provincia/provincia.controller.ts
+++ b/src/models/Provincia/provincia.controller.ts
@@ -8,6 +8,15 @@ export class ProvinciaController {
     const provincia = await provinciaService.create(req.body)
     res.status(201).json(provincia)
   }
+  async getOne(req: Request, res: Response) {
+    const cod_provincia = parseInt(req.params.id, 10)
+    const provincia = await provinciaService.findById(cod_provincia)
+    if (provincia) {
+      res.json(provincia)
+    } else {
+      res.status(404).json({ message: 'Provincia no encontrada' })
+    }
+  }
 
   async getAll(req: Request, res: Response) {
     const provincias = await provinciaService.findAll()

--- a/src/models/Provincia/provincia.repository.ts
+++ b/src/models/Provincia/provincia.repository.ts
@@ -7,6 +7,11 @@ export class ProvinciaRepository {
   constructor() {
     this.prisma = prisma
   }
+  async findById(cod_provincia: number): Promise<provincia | null> {
+    return await this.prisma.provincia.findUnique({
+      where: { cod_provincia },
+    })
+  }
 
   async create(data: Prisma.provinciaCreateInput): Promise<provincia> {
     return await this.prisma.provincia.create({

--- a/src/models/Provincia/provincia.routes.ts
+++ b/src/models/Provincia/provincia.routes.ts
@@ -8,11 +8,12 @@ provinciaRouter.get('/', (req, res) => {
   provinciaController.getAll(req, res)
 })
 
-provinciaRouter.post(
-  '/',
-  (req, res) => {
-    provinciaController.create(req, res)
-  },
-)
+provinciaRouter.get('/:id', (req, res) => {
+  provinciaController.getOne(req, res)
+})
+
+provinciaRouter.post('/', (req, res) => {
+  provinciaController.create(req, res)
+})
 
 export default provinciaRouter

--- a/src/models/Provincia/provincia.service.ts
+++ b/src/models/Provincia/provincia.service.ts
@@ -7,6 +7,9 @@ export class ProvinciaService {
   constructor() {
     this.repository = new ProvinciaRepository()
   }
+  async findById(cod_provincia: number): Promise<provincia | null> {
+    return await this.repository.findById(cod_provincia)
+  }
 
   async create(data: Prisma.provinciaCreateInput): Promise<provincia> {
     return await this.repository.create(data)
@@ -15,5 +18,4 @@ export class ProvinciaService {
   async findAll(): Promise<provincia[]> {
     return await this.repository.findAll()
   }
-
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds functionality to **retrieve localidades by provincia** and implements a **search (buscar)** feature for obras, improving data accessibility and user interaction.

---

### Summary of Changes

- Added logic to fetch **localidades** filtered by selected **provincia**.  
- Implemented **buscar** functionality for obras to enable quick filtering and lookup.  
- Updated related services and routes to support these new operations.  

---

### Purpose

These improvements enhance the system’s usability by allowing users to easily locate obras and manage localidades dynamically based on province selection.
