### PR TITLE
feat: add search functionality for clientes and visitas with pagination

### DIFF
--- a/src/models/Cliente/cliente.controller.ts
+++ b/src/models/Cliente/cliente.controller.ts
@@ -34,6 +34,28 @@ export class ClienteController {
     res.json(cliente)
   }
 
+  async buscar(req: Request, res: Response) {
+    try {
+      const q = String(req.query.q ?? '').trim()
+      const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10))
+      const pageSize = Math.max(
+        1,
+        Math.min(100, parseInt(String(req.query.pageSize ?? '25'), 10)),
+      )
+
+      if (!q) {
+        return res.status(400).json({ message: 'Parametro "q" es requerido' })
+      }
+
+      const clientes = await clienteService.buscar(q, page, pageSize)
+      return res.status(200).json(clientes)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Error desconocido'
+      return res.status(500).json({ error: message })
+    }
+  }
+
   async update(req: Request, res: Response) {
     const cuil = req.params.cuil
     const cliente = await clienteService.update(cuil, req.body)

--- a/src/models/Cliente/cliente.repository.ts
+++ b/src/models/Cliente/cliente.repository.ts
@@ -25,6 +25,21 @@ export class ClienteRepository {
       where: { cuil: cuil },
     })
   }
+  async buscar(q: string, limit?: number, offset?: number): Promise<cliente[]> {
+    return await this.prisma.cliente.findMany({
+      where: {
+        OR: [
+          { razon_social: { contains: q, mode: 'insensitive' } },
+          { cuil: { contains: q, mode: 'insensitive' } },
+          { nombre: { contains: q, mode: 'insensitive' } },
+          { apellido: { contains: q, mode: 'insensitive' } },
+        ],
+      },
+      take: limit,
+      skip: offset,
+      orderBy: { razon_social: 'asc' },
+    })
+  }
 
   async update(
     cuil: string,

--- a/src/models/Cliente/cliente.routes.ts
+++ b/src/models/Cliente/cliente.routes.ts
@@ -6,14 +6,38 @@ import { updateClienteSchema, cuilParamsSchema } from 'sigma-la-schemas'
 const clienteController = new ClienteController()
 const clienteRouter = Router()
 
+/**
+ * @route   GET /api/clientes
+ * @desc    Obtener todos los clientes
+ * @access  Privado (requiere autenticación)
+ */
 clienteRouter.get('/', (req, res) => {
   clienteController.getAll(req, res)
 })
 
+/**
+ * @route   GET /api/clientes/buscar
+ * @desc    Buscar clientes con filtros
+ * @access  Privado (requiere autenticación)
+ */
+clienteRouter.get('/buscar', (req, res) => {
+  clienteController.buscar(req, res)
+})
+
+/**
+ * @route   POST /api/clientes
+ * @desc    Crear nuevo cliente
+ * @access  Privado (requiere autenticación)
+ */
 clienteRouter.post('/', (req, res) => {
   clienteController.create(req, res)
 })
 
+/**
+ * @route   GET /api/clientes/:cuil
+ * @desc    Obtener un cliente por CUIL
+ * @access  Privado (requiere autenticación)
+ */
 clienteRouter.get(
   '/:cuil',
   validate({ params: cuilParamsSchema }),
@@ -22,6 +46,11 @@ clienteRouter.get(
   },
 )
 
+/**
+ * @route   PUT /api/clientes/:cuil
+ * @desc    Actualizar un cliente
+ * @access  Privado (requiere autenticación)
+ */
 clienteRouter.put(
   '/:cuil',
   validate({
@@ -33,6 +62,11 @@ clienteRouter.put(
   },
 )
 
+/**
+ * @route   DELETE /api/clientes/:cuil
+ * @desc    Eliminar un cliente
+ * @access  Privado (requiere autenticación)
+ */
 clienteRouter.delete(
   '/:cuil',
   validate({ params: cuilParamsSchema }),

--- a/src/models/Cliente/cliente.service.ts
+++ b/src/models/Cliente/cliente.service.ts
@@ -36,6 +36,12 @@ export class ClienteService {
     return await this.repository.findById(cuil)
   }
 
+  async buscar(q: string, page = 1, pageSize = 25): Promise<cliente[]> {
+    const limit = Math.max(1, Math.min(100, pageSize))
+    const offset = (Math.max(1, page) - 1) * limit
+    return await this.repository.buscar(q, limit, offset)
+  }
+
   async update(
     cuil: string,
     data: Prisma.clienteUpdateInput,

--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -33,6 +33,28 @@ export class VisitaController {
     res.json(visita)
   }
 
+  async buscar(req: Request, res: Response) {
+    try {
+      const q = String(req.query.q ?? '').trim()
+      const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10))
+      const pageSize = Math.max(
+        1,
+        Math.min(100, parseInt(String(req.query.pageSize ?? '25'), 10)),
+      )
+
+      if (!q) {
+        return res.status(400).json({ message: 'Parametro "q" es requerido' })
+      }
+
+      const visitas = await visitaService.buscar(q, page, pageSize)
+      return res.status(200).json(visitas)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Error desconocido'
+      return res.status(500).json({ error: message })
+    }
+  }
+
   async update(req: Request, res: Response) {
     const { id } = req.params
     const visita = await visitaService.update(Number(id), req.body)

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -148,6 +148,55 @@ export class VisitaRepository {
       },
     })
   }
+
+  async buscar(q: string, limit?: number, offset?: number): Promise<visita[]> {
+    return await this.prisma.visita.findMany({
+      where: {
+        OR: [
+          { direccion_visita: { contains: q, mode: 'insensitive' } },
+          { nombre_cliente: { contains: q, mode: 'insensitive' } },
+          { apellido_cliente: { contains: q, mode: 'insensitive' } },
+          {
+            obra: {
+              cliente: {
+                OR: [
+                  { nombre: { contains: q, mode: 'insensitive' } },
+                  { apellido: { contains: q, mode: 'insensitive' } },
+                  { razon_social: { contains: q, mode: 'insensitive' } },
+                ],
+              },
+            },
+          },
+          {
+            obra: {
+              direccion: { contains: q, mode: 'insensitive' },
+            },
+          },
+        ],
+      },
+      include: {
+        obra: {
+          include: {
+            cliente: true,
+          },
+        },
+        empleado_visita: {
+          include: {
+            empleado: true,
+          },
+        },
+        uso_vehiculo_visita: {
+          include: {
+            vehiculo: true,
+          },
+        },
+      },
+      take: limit,
+      skip: offset,
+      orderBy: { fecha_hora_visita: 'desc' },
+    })
+  }
+
   async findByEmpleadoAndEstado(
     cuil: string,
     estado: string,

--- a/src/models/Visita/visita.routes.ts
+++ b/src/models/Visita/visita.routes.ts
@@ -14,6 +14,10 @@ visitaRouter.post('/', (req, res) => {
   visitaController.create(req, res)
 })
 
+visitaRouter.get('/buscar', (req, res) => {
+  visitaController.buscar(req, res)
+})
+
 visitaRouter.get('/:id', validate({ params: idParamsSchema }), (req, res) => {
   visitaController.getOne(req, res)
 })

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -47,7 +47,6 @@ export class VisitaService {
     )
 
     const createData = {
-      // ... otros campos de la visita (fecha_hora_visita, motivo_visita, etc.)
       fecha_hora_visita: new Date(data.fecha_hora_visita),
       motivo_visita: data.motivo_visita,
       estado: 'PROGRAMADA',
@@ -58,37 +57,25 @@ export class VisitaService {
       apellido_cliente: data.apellido_cliente,
       telefono_cliente: data.telefono_cliente,
 
-      // Conexiones
       ...(data.cod_obra && { obra: { connect: { cod_obra: data.cod_obra } } }),
       ...(data.cod_localidad && {
         localidad: { connect: { cod_localidad: data.cod_localidad } },
       }),
 
-      // Relación con empleados (esto ya estaba bien)
       empleado_visita: {
         createMany: {
           data: empleadosParaCrear,
           skipDuplicates: true,
         },
       },
-
-      // --- ¡LA CORRECCIÓN FINAL ESTÁ AQUÍ! ---
-      // Relación con el uso del vehículo
       uso_vehiculo_visita: {
         create: {
-          // 1. Conectamos con el vehículo existente a través de la patente.
           vehiculo: {
             connect: {
               patente: data.vehiculo,
             },
           },
-
-          // 2. Proporcionamos los campos OBLIGATORIOS de la tabla 'uso_vehiculo_visita'.
-          //    Estos valores los podemos tomar de la propia visita.
           fecha_hora_ini_uso: new Date(data.fecha_hora_visita),
-
-          // Asumimos que la fecha fin estimada es la fecha fin de la visita.
-          // Si el frontend envía `fechaHasta`, úsala. Si no, usa la fecha de inicio.
           fecha_hora_fin_est: new Date(
             data.fechaHasta || data.fecha_hora_visita,
           ),
@@ -107,6 +94,12 @@ export class VisitaService {
   // Obtener visita por cod_visita
   async findById(cod_visita: number): Promise<visita | null> {
     return await this.visitaRepository.findById(cod_visita)
+  }
+
+  async buscar(q: string, page = 1, pageSize = 25): Promise<visita[]> {
+    const limit = Math.max(1, Math.min(100, pageSize))
+    const offset = (Math.max(1, page) - 1) * limit
+    return await this.visitaRepository.buscar(q, limit, offset)
   }
 
   // Actualizar visita


### PR DESCRIPTION
## Pull Request Overview

This PR adds **search functionality with pagination** for both **Clientes** and **Visitas**, improving data accessibility and navigation efficiency across the application.

---

### Summary of Changes

- Implemented **search endpoints and logic** for `clientes` and `visitas`.  
- Added **pagination support** to handle large datasets more efficiently.  
- Updated related components and services to integrate the new search and pagination features.  

---

### Purpose

These improvements enhance the **user experience** by allowing quick searches and smoother navigation through client and visit records, ensuring scalability and performance in data-heavy views.
