### PR TITLE
Refactor/clientes view

### DIFF
--- a/src/models/Cliente/cliente.controller.ts
+++ b/src/models/Cliente/cliente.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
 import { ClienteService } from './cliente.service.js'
 
 const clienteService = new ClienteService()
@@ -62,9 +62,37 @@ export class ClienteController {
     res.json(cliente)
   }
 
-  async remove(req: Request, res: Response) {
-    const cuil = req.params.cuil
-    const cliente = await clienteService.remove(cuil)
-    res.json(cliente)
+  async remove(req: Request, res: Response, next?: NextFunction) {
+    try {
+      const cuil = req.params.cuil
+      const result = await clienteService.remove(cuil)
+
+      if (result.status === 'not_found') {
+        return res.status(404).json({
+          code: 'CLIENTE_NO_ENCONTRADO',
+          message: 'Cliente no encontrado',
+        })
+      }
+
+      if (result.status === 'has_dependencies') {
+        return res.status(409).json({
+          code: 'CLIENTE_CON_DEPENDENCIAS',
+          message:
+            'No se puede eliminar el cliente porque tiene obras o visitas asociadas. Debe desvincularlas antes.',
+          details: result.details,
+        })
+      }
+
+      return res.status(204).send()
+    } catch (error: unknown) {
+      if (next) {
+        return next(error)
+      }
+
+      return res.status(500).json({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Error interno del servidor',
+      })
+    }
   }
 }

--- a/src/models/Cliente/cliente.repository.ts
+++ b/src/models/Cliente/cliente.repository.ts
@@ -1,6 +1,12 @@
 import { PrismaClient, cliente, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
 
+export interface ClienteDeleteDependencyCounts {
+  obras: number
+  visitasConObra: number
+  visitasInicialesSinObra: number
+}
+
 export class ClienteRepository {
   private prisma: PrismaClient
 
@@ -55,5 +61,30 @@ export class ClienteRepository {
     return await this.prisma.cliente.delete({
       where: { cuil: cuil },
     })
+  }
+
+  async countDeleteDependencies(
+    cuil: string,
+  ): Promise<ClienteDeleteDependencyCounts> {
+    const [obras, visitasConObra] = await this.prisma.$transaction([
+      this.prisma.obra.count({
+        where: {
+          OR: [{ cuil }, { cuil_arquitecto: cuil }],
+        },
+      }),
+      this.prisma.visita.count({
+        where: {
+          obra: {
+            OR: [{ cuil }, { cuil_arquitecto: cuil }],
+          },
+        },
+      }),
+    ])
+
+    return {
+      obras,
+      visitasConObra,
+      visitasInicialesSinObra: 0,
+    }
   }
 }

--- a/src/models/Cliente/cliente.routes.ts
+++ b/src/models/Cliente/cliente.routes.ts
@@ -70,8 +70,8 @@ clienteRouter.put(
 clienteRouter.delete(
   '/:cuil',
   validate({ params: cuilParamsSchema }),
-  (req, res) => {
-    clienteController.remove(req, res)
+  (req, res, next) => {
+    clienteController.remove(req, res, next)
   },
 )
 

--- a/src/models/Cliente/cliente.service.ts
+++ b/src/models/Cliente/cliente.service.ts
@@ -1,6 +1,17 @@
 import { Prisma, cliente } from '@prisma/client'
 import { ClienteRepository } from './cliente.repository.js'
 
+export interface ClienteDependencyDetails {
+  obras: number
+  visitasConObra: number
+  visitasInicialesSinObra: number
+}
+
+export type ClienteRemoveResult =
+  | { status: 'deleted'; cliente: cliente }
+  | { status: 'not_found' }
+  | { status: 'has_dependencies'; details: ClienteDependencyDetails }
+
 /**
  * Servicio para manejar operaciones CRUD de clientes.
  * @class ClienteService
@@ -53,11 +64,43 @@ export class ClienteService {
     return await this.repository.update(cuil, data)
   }
 
-  async remove(cuil: string): Promise<cliente> {
+  async remove(cuil: string): Promise<ClienteRemoveResult> {
     const existingCliente = await this.repository.findById(cuil)
     if (!existingCliente) {
-      throw new Error('No existe un cliente con el CUIL proporcionado.')
+      return { status: 'not_found' }
     }
-    return await this.repository.delete(cuil)
+
+    const dependencyCounts = await this.repository.countDeleteDependencies(cuil)
+
+    if (
+      dependencyCounts.obras > 0 ||
+      dependencyCounts.visitasConObra > 0 ||
+      dependencyCounts.visitasInicialesSinObra > 0
+    ) {
+      return {
+        status: 'has_dependencies',
+        details: dependencyCounts,
+      }
+    }
+
+    try {
+      const deletedCliente = await this.repository.delete(cuil)
+      return { status: 'deleted', cliente: deletedCliente }
+    } catch (error: unknown) {
+      // Safety net for concurrent writes between dependency check and delete.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2003'
+      ) {
+        const refreshedDependencyCounts =
+          await this.repository.countDeleteDependencies(cuil)
+        return {
+          status: 'has_dependencies',
+          details: refreshedDependencyCounts,
+        }
+      }
+
+      throw error
+    }
   }
 }

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -42,6 +42,19 @@ export class ObraController {
     }
   }
 
+  /** Obtiene obras de un cliente específico */
+  async getByCliente(req: Request, res: Response) {
+    try {
+      const cuil_cliente = req.params.cuil_cliente
+      const obras = await obraService.findByCliente(cuil_cliente)
+      res.json(obras)
+    } catch (error) {
+      res
+        .status(500)
+        .json({ message: 'Error al obtener obras por cliente', error })
+    }
+  }
+
   /** Obtiene todas las obras */
   async getAll(req: Request, res: Response) {
     const obras = await obraService.findAll()

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -94,6 +94,25 @@ export class ObraRepository {
     })
   }
 
+  /** Obtiene obras de un cliente específico */
+  async findByCliente(cuil_cliente: string) {
+    return this.prisma.obra.findMany({
+      where: {
+        cliente: {
+          cuil: cuil_cliente,
+        },
+      },
+      include: {
+        localidad: {
+          include: {
+            provincia: true,
+          },
+        },
+      },
+      orderBy: { cod_obra: 'desc' },
+    })
+  }
+
   /** Obtiene una obra por ID */
   async findById(id: number): Promise<obra | null> {
     return await this.prisma.obra.findUnique({

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -26,6 +26,11 @@ obraRouter.get('/buscar', (req, res) => {
   obraController.buscar(req, res)
 })
 
+// Obtener obras de un cliente específico
+obraRouter.get('/cliente/:cuil_cliente', (req, res) => {
+  obraController.getByCliente(req, res)
+})
+
 // Obtener obras listas para pedido de stock
 obraRouter.get('/para-pedido-stock', (req, res) => {
   obraController.getObrasParaPedidoStock(req, res)

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -35,6 +35,11 @@ export class ObraService {
     return this.repository.buscar(q)
   }
 
+  /** Obtiene obras de un cliente específico */
+  async findByCliente(cuil_cliente: string) {
+    return this.repository.findByCliente(cuil_cliente)
+  }
+
   /** Obtiene todas las obras */
   async findAll(): Promise<obra[]> {
     return this.repository.findAll()

--- a/src/shared/middlewares/errorHandler.ts
+++ b/src/shared/middlewares/errorHandler.ts
@@ -1,8 +1,24 @@
 import express from 'express'
+import { Prisma } from '@prisma/client'
 import { env } from '../../config/env.js'
 
+interface ApiErrorPayload {
+  status?: number
+  code?: string
+  message?: string
+  details?: unknown
+}
+
+const isApiErrorPayload = (value: unknown): value is ApiErrorPayload => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  return true
+}
+
 export const errorHandler = (
-  err: Error,
+  err: unknown,
   req: express.Request,
   res: express.Response,
   next: express.NextFunction,
@@ -13,9 +29,29 @@ export const errorHandler = (
     return next(err)
   }
 
+  if (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === 'P2003'
+  ) {
+    return res.status(409).json({
+      code: 'CLIENTE_CON_DEPENDENCIAS',
+      message:
+        'No se puede eliminar el cliente porque tiene obras o visitas asociadas. Debe desvincularlas antes.',
+    })
+  }
+
+  if (isApiErrorPayload(err) && typeof err.status === 'number') {
+    return res.status(err.status).json({
+      code: err.code ?? 'APPLICATION_ERROR',
+      message: err.message ?? 'Error de aplicacion',
+      details: err.details,
+    })
+  }
+
+  const message = err instanceof Error ? err.message : 'Something went wrong'
+
   res.status(500).json({
-    error: 'Internal server error',
-    message:
-      env.NODE_ENV === 'development' ? err.message : 'Something went wrong',
+    code: 'INTERNAL_SERVER_ERROR',
+    message: env.NODE_ENV === 'development' ? message : 'Something went wrong',
   })
 }


### PR DESCRIPTION
### Resumen
Este PR mejora la eliminación de clientes para que sea más robusta y predecible. Se implementó manejo explícito de dependencias y errores, devolviendo respuestas HTTP consistentes para frontend.

### Cambios Técnicos Implementados
- Se agregó pre-chequeo de dependencias antes del DELETE de cliente, contando obras y visitas asociadas.
- Se implementó respuesta `409` cuando hay dependencias, con payload estandarizado:
  - `code`: `CLIENTE_CON_DEPENDENCIAS`
  - `message`: `No se puede eliminar el cliente porque tiene obras o visitas asociadas. Debe desvincularlas antes.`
  - `details`: conteos de dependencias
- Se mantuvo `404` para cliente inexistente y `204` para eliminación exitosa.
- Se agregó captura de Prisma `P2003` como red de seguridad ante concurrencia (aunque pase el pre-chequeo).
- Se ajustó el flujo para no propagar errores crudos de Prisma.
- Se reforzó el error handler global para responder siempre JSON y manejar errores inesperados sin tumbar el servidor.

---

### Guía para Pruebas y Revisión
1. Iniciar el servidor y autenticarse como siempre en el proyecto.
2. Probar `DELETE /api/clientes/:cuil` con un cliente sin dependencias.
   - Esperado: `204`.
3. Probar `DELETE /api/clientes/:cuil` con un cliente con obras/visitas asociadas.
   - Esperado: `409` con `code` `CLIENTE_CON_DEPENDENCIAS` y `details`.
4. Probar `DELETE /api/clientes/:cuil` con un CUIL inexistente.
   - Esperado: `404`.
5. Verificar que ante error inesperado la API responde JSON con `500` y el servidor sigue operativo.

### Screenshots (Opcional)
No aplica (cambios de backend).