### PR TITLE
feat: add express-rate-limit for global and login routes to enhance s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.3.2",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      express-rate-limit:
+        specifier: ^8.3.2
+        version: 8.3.2(express@5.1.0)
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -1731,6 +1734,12 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -1925,6 +1934,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4880,6 +4893,11 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  express-rate-limit@8.3.2(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+      ip-address: 10.1.0
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -5107,6 +5125,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@4.1.1: {}
+
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import * as Sentry from '@sentry/node'
 import express from 'express'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
+import helmet from 'helmet'
+import { rateLimit } from 'express-rate-limit'
 import { env } from './config/env.js'
 import ROUTES from './shared/routes/index.routes.js'
 import authRouter from './models/Auth/auth.routes.js'
@@ -12,19 +14,54 @@ import healthRouter from './shared/routes/health.routes.js'
 const app = express()
 const PORT = env.PORT
 
+const globalRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 1000,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'Demasiadas solicitudes, intenta nuevamente en un minuto.',
+  },
+  handler: (req, res, _next, options) => {
+    console.warn(
+      `[RATE_LIMIT][GLOBAL] Bloqueado ${req.ip} en ${req.method} ${req.originalUrl}`,
+    )
+
+    res.status(options.statusCode).json(options.message)
+  },
+})
+
 app.use(
   cors({
-    origin: env.FRONTEND_URL,
+    origin: (origin, callback) => {
+      if (!origin || origin === env.FRONTEND_URL) {
+        callback(null, true)
+        return
+      }
+
+      callback(new Error('CORS bloqueado para este origen'))
+    },
     credentials: true,
   }),
 )
 
+app.use(helmet())
 app.use(express.json())
 app.use(cookieParser())
+app.use('/api', globalRateLimit)
 
 app.use('/api', healthRouter)
 
 app.use('/api/auth', authRouter)
+
+app.use('/api', (req, res, next) => {
+  if (req.path === '/login' || req.path === '/login/') {
+    authRouter(req, res, next)
+    return
+  }
+
+  next()
+})
 
 app.use(authenticateJWT)
 

--- a/src/models/Auth/auth.controller.ts
+++ b/src/models/Auth/auth.controller.ts
@@ -4,6 +4,13 @@ import { parse } from 'valibot'
 import { Request, Response } from 'express'
 import { env } from '../../config/env.js'
 
+const baseCookieOptions = {
+  httpOnly: true,
+  secure: env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  path: '/',
+}
+
 /**
  * Controlador para manejar los endpoints de autenticación.
  * @class AuthController
@@ -38,18 +45,12 @@ export class AuthController {
       )
 
       res.cookie('accessToken', token, {
-        httpOnly: true,
-        secure: env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        ...baseCookieOptions,
         maxAge: 8 * 60 * 60 * 1000,
-        path: '/',
       })
       res.cookie('refreshToken', refreshToken, {
-        httpOnly: true,
-        secure: env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        ...baseCookieOptions,
         maxAge: 30 * 24 * 60 * 60 * 1000,
-        path: '/',
       })
 
       const usuarioSeguro = {
@@ -60,11 +61,8 @@ export class AuthController {
       }
 
       res.cookie('usuario', JSON.stringify(usuarioSeguro), {
-        httpOnly: true,
-        secure: env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        ...baseCookieOptions,
         maxAge: 8 * 60 * 60 * 1000,
-        path: '/',
       })
 
       res.status(200).json({
@@ -81,9 +79,9 @@ export class AuthController {
 
   async logout(req: Request, res: Response) {
     try {
-      res.clearCookie('accessToken')
-      res.clearCookie('refreshToken')
-      res.clearCookie('usuario')
+      res.clearCookie('accessToken', baseCookieOptions)
+      res.clearCookie('refreshToken', baseCookieOptions)
+      res.clearCookie('usuario', baseCookieOptions)
       const refreshToken = req.cookies?.refreshToken || req.body.refreshToken
       await this.authService.logout(refreshToken)
       res.status(204).send()
@@ -114,9 +112,7 @@ export class AuthController {
       }
       const { token } = await this.authService.refreshAccessToken(refreshToken)
       res.cookie('accessToken', token, {
-        httpOnly: true,
-        secure: env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        ...baseCookieOptions,
         maxAge: 8 * 60 * 60 * 1000,
       })
       res.status(200).json({ message: 'Token refrescado' })

--- a/src/models/Auth/auth.routes.ts
+++ b/src/models/Auth/auth.routes.ts
@@ -1,8 +1,9 @@
-import { Router } from 'express'
+import { Router, type NextFunction, type Request, type Response } from 'express'
 import { AuthController } from './auth.controller.js'
 import { validate } from '../../shared/middlewares/validateSchemas.js'
 import { registerSchema, loginSchema } from './auth.schemas.js'
 import { authenticateJWT } from './auth.middleware.js'
+import { rateLimit } from 'express-rate-limit'
 
 /**
  
@@ -11,11 +12,42 @@ Rutas para autenticación de empleados.
 const authController = new AuthController()
 const router = Router()
 
+const loginAttemptLogger = (req: Request, _res: Response, next: NextFunction) => {
+  const safeCuil = req.body?.cuil ? String(req.body.cuil) : 'sin-cuil'
+
+  console.info(
+    `[AUTH][LOGIN_ATTEMPT] ${new Date().toISOString()} ip=${req.ip} cuil=${safeCuil} ${req.method} ${req.originalUrl}`,
+  )
+
+  next()
+}
+
+const loginRateLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'Demasiados intentos de login. Intenta nuevamente en 15 minutos.',
+  },
+  handler: (req, res, _next, options) => {
+    console.warn(
+      `[RATE_LIMIT][LOGIN] Bloqueado ${req.ip} en ${req.method} ${req.originalUrl}`,
+    )
+
+    res.status(options.statusCode).json(options.message)
+  },
+})
+
 router.post('/register', validate({ body: registerSchema }), (req, res) =>
   authController.register(req, res),
 )
-router.post('/login', validate({ body: loginSchema }), (req, res) =>
-  authController.login(req, res),
+router.post(
+  '/login',
+  loginAttemptLogger,
+  loginRateLimit,
+  validate({ body: loginSchema }),
+  (req, res) => authController.login(req, res),
 )
 router.post('/logout', (req, res) => authController.logout(req, res))
 


### PR DESCRIPTION
### Issue Relacionada
Closes #126 

---

### Resumen
Este PR incorpora hardening básico de seguridad en la API mediante headers HTTP seguros y límites de solicitudes por IP.
También se ajustó el flujo de login para cubrir tanto `/api/auth/login` como `/api/login` bajo la misma protección.

### Cambios Técnicos Implementados
- Se integró `helmet` como middleware global para agregar headers de seguridad HTTP.
- Se configuró rate limit global de **1000 requests por minuto por IP**.
- Se configuró rate limit estricto para login de **10 intentos cada 15 minutos por IP**.
- Se aseguró que login por `/api/login` y `/api/auth/login` pase por la misma política de rate limiting.
- Se mantuvo CORS restringido al origen permitido y `credentials: true`.
- Se consolidaron opciones de cookies seguras:
  - `httpOnly: true`
  - `secure: true` en producción
  - `sameSite: 'strict'`
- Se agregaron logs de depuración para verificar intentos de login y bloqueos por rate limit.

---

### Guía para Pruebas y Revisión
1. Iniciar el servidor en modo desarrollo (`pnpm start:dev`).
2. Probar login inválido repetidas veces en `POST /api/login` o `POST /api/auth/login`.
3. Verificar comportamiento esperado:
   - Intentos iniciales: `401` (credenciales inválidas).
   - Al superar el límite: `429` (too many requests).
4. Verificar en la respuesta la presencia de headers de seguridad de `helmet`.
5. Verificar que CORS permita solo el `FRONTEND_URL` configurado y soporte credenciales.
6. Verificar que las cookies de autenticación se envían con `httpOnly`, `sameSite='strict'` y `secure` en producción.

### Screenshots (Opcional)
No aplica para este PR (cambios de backend sin interfaz visual).