### PR TITLE
Feat/entregas-parciales

### DIFF
--- a/prisma/migrations/20260331182700_entrega_es_final_op_relacion_1_a_n/migration.sql
+++ b/prisma/migrations/20260331182700_entrega_es_final_op_relacion_1_a_n/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable: agregar columna esFinal a entrega con default false
+ALTER TABLE "entrega" ADD COLUMN "esFinal" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: agregar columna cod_entrega a orden_de_produccion (FK nullable)
+ALTER TABLE "orden_de_produccion" ADD COLUMN "cod_entrega" INTEGER;
+
+-- DropIndex: eliminar el unique constraint de cod_op en entrega (relacion 1-a-1 anterior)
+DROP INDEX IF EXISTS "entrega_cod_op_key";
+
+-- AlterTable: eliminar la columna cod_op de entrega (la FK estaba del lado de entrega antes)
+ALTER TABLE "entrega" DROP COLUMN IF EXISTS "cod_op";
+
+-- AddForeignKey: orden_de_produccion -> entrega (N OP a 1 entrega)
+ALTER TABLE "orden_de_produccion" ADD CONSTRAINT "orden_de_produccion_cod_entrega_fkey" FOREIGN KEY ("cod_entrega") REFERENCES "entrega"("cod_entrega") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,9 +51,9 @@ model entrega {
   cod_entrega          Int                    @id @default(autoincrement())
   dias_viaticos        Int?
   fecha_cancelacion    DateTime?              @db.Date
-  cod_op               Int?                   @unique
+  esFinal              Boolean                @default(false)
   obra                 obra                   @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
-  orden_de_produccion  orden_de_produccion?   @relation(fields: [cod_op], references: [cod_op])
+  ordenes_de_produccion orden_de_produccion[]
   entrega_empleado     entrega_empleado[]
   uso_maquinaria       uso_maquinaria[]
   uso_vehiculo_entrega uso_vehiculo_entrega[]
@@ -125,7 +125,8 @@ model orden_de_produccion {
   cod_op           Int       @id @default(autoincrement())
   public_id        String?   @db.VarChar(255)
   estado           String    @default("PENDIENTE") @db.VarChar(255)
-  entrega          entrega?
+  cod_entrega      Int?
+  entrega          entrega?  @relation(fields: [cod_entrega], references: [cod_entrega])
   obra             obra      @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
 }
 

--- a/src/models/Entrega/entrega.controller.ts
+++ b/src/models/Entrega/entrega.controller.ts
@@ -11,6 +11,8 @@ const entregaService = new EntregaService()
  * @method getOne - Maneja la obtención de una entrega por su ID.
  * @method update - Maneja la actualización de una entrega existente.
  * @method remove - Maneja la eliminación de una entrega por su ID.
+ * @method agregarOPs - Vincula órdenes de producción a una entrega.
+ * @method quitarOPs - Desvincula órdenes de producción de una entrega.
  * @returns {Promise<void>} - Respuesta HTTP.
  * @throws {Error} - Si ocurre un error durante la operación.
  */
@@ -66,7 +68,7 @@ export class EntregaController {
       cuil_empleado,
       estado,
       search,
-      date
+      date,
     )
     res.json(entregas)
   }
@@ -95,6 +97,44 @@ export class EntregaController {
       console.error('Error al cancelar entrega:', error)
       const message =
         error instanceof Error ? error.message : 'Error al cancelar la entrega'
+      res.status(400).json({ message })
+    }
+  }
+
+  /** PATCH /:id/ordenes-produccion — vincula OPs a una entrega */
+  async agregarOPs(req: Request, res: Response) {
+    try {
+      const cod_entrega = parseInt(req.params.id)
+      const { cod_ops } = req.body as { cod_ops: number[] }
+      const entrega = await entregaService.agregarOrdenesDeProduccion(
+        cod_entrega,
+        cod_ops,
+      )
+      res.json(entrega)
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Error al agregar órdenes de producción'
+      res.status(400).json({ message })
+    }
+  }
+
+  /** DELETE /:id/ordenes-produccion — desvincula OPs de una entrega */
+  async quitarOPs(req: Request, res: Response) {
+    try {
+      const cod_entrega = parseInt(req.params.id)
+      const { cod_ops } = req.body as { cod_ops: number[] }
+      const entrega = await entregaService.quitarOrdenesDeProduccion(
+        cod_entrega,
+        cod_ops,
+      )
+      res.json(entrega)
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Error al quitar órdenes de producción'
       res.status(400).json({ message })
     }
   }

--- a/src/models/Entrega/entrega.repository.ts
+++ b/src/models/Entrega/entrega.repository.ts
@@ -2,6 +2,46 @@ import { PrismaClient, entrega, Prisma } from '@prisma/client'
 
 import { prisma } from '../../shared/db/prismaClient.js'
 
+const defaultInclude = {
+  obra: {
+    include: {
+      cliente: true,
+      localidad: true,
+    },
+  },
+  entrega_empleado: {
+    include: {
+      empleado: {
+        select: {
+          cuil: true,
+          nombre: true,
+          apellido: true,
+        },
+      },
+    },
+  },
+  uso_maquinaria: {
+    include: {
+      maquinaria: {
+        select: {
+          descripcion: true,
+        },
+      },
+    },
+  },
+  uso_vehiculo_entrega: {
+    include: {
+      vehiculo: {
+        select: {
+          patente: true,
+          tipo_vehiculo: true,
+        },
+      },
+    },
+  },
+  ordenes_de_produccion: true,
+} satisfies Prisma.entregaInclude
+
 export class EntregaRepository {
   private prisma: PrismaClient
 
@@ -46,45 +86,7 @@ export class EntregaRepository {
     return this.prisma.entrega.findMany({
       where: whereClause,
       orderBy: { fecha_hora_entrega: 'desc' },
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
-          },
-        },
-        entrega_empleado: {
-          include: {
-            empleado: {
-              select: {
-                cuil: true,
-                nombre: true,
-                apellido: true,
-              },
-            },
-          },
-        },
-        uso_maquinaria: {
-          include: {
-            maquinaria: {
-              select: {
-                descripcion: true,
-              },
-            },
-          },
-        },
-        uso_vehiculo_entrega: {
-          include: {
-            vehiculo: {
-              select: {
-                patente: true,
-                tipo_vehiculo: true,
-              },
-            },
-          },
-        },
-        orden_de_produccion: true,
-      },
+      include: defaultInclude,
     })
   }
 
@@ -138,45 +140,7 @@ export class EntregaRepository {
 
     return this.prisma.entrega.findMany({
       where: whereClause,
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
-          },
-        },
-        entrega_empleado: {
-          include: {
-            empleado: {
-              select: {
-                cuil: true,
-                nombre: true,
-                apellido: true,
-              },
-            },
-          },
-        },
-        uso_maquinaria: {
-          include: {
-            maquinaria: {
-              select: {
-                descripcion: true,
-              },
-            },
-          },
-        },
-        uso_vehiculo_entrega: {
-          include: {
-            vehiculo: {
-              select: {
-                patente: true,
-                tipo_vehiculo: true,
-              },
-            },
-          },
-        },
-        orden_de_produccion: true,
-      },
+      include: defaultInclude,
       orderBy: { fecha_hora_entrega: 'desc' },
     })
   }
@@ -184,45 +148,7 @@ export class EntregaRepository {
   async findById(cod_entrega: number): Promise<entrega | null> {
     return this.prisma.entrega.findUnique({
       where: { cod_entrega },
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
-          },
-        },
-        entrega_empleado: {
-          include: {
-            empleado: {
-              select: {
-                cuil: true,
-                nombre: true,
-                apellido: true,
-              },
-            },
-          },
-        },
-        uso_maquinaria: {
-          include: {
-            maquinaria: {
-              select: {
-                descripcion: true,
-              },
-            },
-          },
-        },
-        uso_vehiculo_entrega: {
-          include: {
-            vehiculo: {
-              select: {
-                patente: true,
-                tipo_vehiculo: true,
-              },
-            },
-          },
-        },
-        orden_de_produccion: true,
-      },
+      include: defaultInclude,
     })
   }
 
@@ -233,45 +159,7 @@ export class EntregaRepository {
     return this.prisma.entrega.update({
       where: { cod_entrega },
       data,
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
-          },
-        },
-        entrega_empleado: {
-          include: {
-            empleado: {
-              select: {
-                cuil: true,
-                nombre: true,
-                apellido: true,
-              },
-            },
-          },
-        },
-        uso_maquinaria: {
-          include: {
-            maquinaria: {
-              select: {
-                descripcion: true,
-              },
-            },
-          },
-        },
-        uso_vehiculo_entrega: {
-          include: {
-            vehiculo: {
-              select: {
-                patente: true,
-                tipo_vehiculo: true,
-              },
-            },
-          },
-        },
-        orden_de_produccion: true,
-      },
+      include: defaultInclude,
     })
   }
 

--- a/src/models/Entrega/entrega.routes.ts
+++ b/src/models/Entrega/entrega.routes.ts
@@ -48,4 +48,13 @@ entregaRouter.patch('/:id/cancelar', (req, res) => {
   entregaController.cancelarEntrega(req, res)
 })
 
+// Gestión de órdenes de producción vinculadas a una entrega
+entregaRouter.patch('/:id/ordenes-produccion', (req, res) => {
+  entregaController.agregarOPs(req, res)
+})
+
+entregaRouter.delete('/:id/ordenes-produccion', (req, res) => {
+  entregaController.quitarOPs(req, res)
+})
+
 export default entregaRouter

--- a/src/models/Entrega/entrega.service.ts
+++ b/src/models/Entrega/entrega.service.ts
@@ -188,6 +188,18 @@ export class EntregaService {
       '--- Payload final enviado a Prisma ---',
       JSON.stringify(payload, null, 2),
     )
+
+    if (esFinal) {
+      return prisma.$transaction(async tx => {
+        const nuevaEntrega = await tx.entrega.create({ data: payload })
+        await tx.obra.update({
+          where: { cod_obra },
+          data: { estado: 'ENTREGADA' },
+        })
+        return nuevaEntrega
+      })
+    }
+
     return this.entregaRepository.create(payload)
   }
 

--- a/src/models/Entrega/entrega.service.ts
+++ b/src/models/Entrega/entrega.service.ts
@@ -13,6 +13,8 @@ import { EmpleadoService } from '../Empleado/empleado.service.js'
  * @method findById - Obtiene una entrega por cod_entrega.
  * @method update - Actualiza una entrega existente.
  * @method delete - Elimina una entrega por su cod_entrega.
+ * @method agregarOrdenesDeProduccion - Vincula OPs a una entrega existente.
+ * @method quitarOrdenesDeProduccion - Desvincula OPs de una entrega.
  * @returns {Promise<entrega | entrega[] | number | null>} - Resultado de la operación.
  * @throws {Error} - Si ocurre un error durante la operación.
  */
@@ -39,18 +41,20 @@ export class EntregaService {
     dias_viaticos?: number
     fecha_salida_estimada?: string
     fecha_regreso_estimado?: string
+    esFinal?: boolean
     empleados: { cuil: string; rol_entrega: 'ENCARGADO' | 'AYUDANTE' }[]
     maquinarias?: number[]
     vehiculos?: string[]
-    cod_op?: number
+    cod_ops?: number[]
   }): Promise<entrega> {
     const {
       empleados,
       cod_obra,
       maquinarias,
       vehiculos,
-      cod_op,
+      cod_ops,
       dias_viaticos,
+      esFinal,
       fecha_salida_estimada,
       fecha_regreso_estimado,
       ...entregaData
@@ -132,6 +136,7 @@ export class EntregaService {
       detalle: entregaData.detalle,
       estado: entregaData.estado,
       fecha_hora_entrega: fechaParaPrisma,
+      esFinal: esFinal ?? false,
       ...(entregaData.observaciones && {
         observaciones: entregaData.observaciones,
       }),
@@ -150,29 +155,31 @@ export class EntregaService {
       },
       ...(maquinarias &&
         maquinarias.length > 0 && {
-          uso_maquinaria: {
-            create: maquinarias.map(cod_maquina => ({
-              maquinaria: { connect: { cod_maquina: cod_maquina } },
-              fecha_hora_ini_uso: fechaSalidaPrisma,
-              fecha_hora_fin_est: fechaFinEstimada,
-              obra: { connect: { cod_obra: cod_obra } },
-            })),
-          },
-        }),
+        uso_maquinaria: {
+          create: maquinarias.map(cod_maquina => ({
+            maquinaria: { connect: { cod_maquina: cod_maquina } },
+            fecha_hora_ini_uso: fechaSalidaPrisma,
+            fecha_hora_fin_est: fechaFinEstimada,
+            obra: { connect: { cod_obra: cod_obra } },
+          })),
+        },
+      }),
       ...(vehiculos &&
         vehiculos.length > 0 && {
-          uso_vehiculo_entrega: {
-            create: vehiculos.map(patente => ({
-              vehiculo: { connect: { patente: patente } },
-              fecha_hora_ini_uso: fechaSalidaPrisma,
-              fecha_hora_ini_est: fechaFinEstimada,
-              obra: { connect: { cod_obra: cod_obra } },
-            })),
-          },
-        }),
-      ...(cod_op && {
-        orden_de_produccion: {
-          connect: { cod_op: cod_op },
+        uso_vehiculo_entrega: {
+          create: vehiculos.map(patente => ({
+            vehiculo: { connect: { patente: patente } },
+            fecha_hora_ini_uso: fechaSalidaPrisma,
+            fecha_hora_ini_est: fechaFinEstimada,
+            obra: { connect: { cod_obra: cod_obra } },
+          })),
+        },
+      }),
+      // Vincular órdenes de producción al crear (N OPs por entrega)
+      ...(cod_ops &&
+        cod_ops.length > 0 && {
+        ordenes_de_produccion: {
+          connect: cod_ops.map(cod_op => ({ cod_op })),
         },
       }),
     }
@@ -221,13 +228,81 @@ export class EntregaService {
     )
   }
 
+  /**
+   * Vincula una o varias órdenes de producción a una entrega existente.
+   * @param cod_entrega - ID de la entrega destino
+   * @param cod_ops - Array de IDs de órdenes de producción a vincular
+   */
+  async agregarOrdenesDeProduccion(
+    cod_entrega: number,
+    cod_ops: number[],
+  ): Promise<entrega> {
+    if (!cod_ops || cod_ops.length === 0) {
+      throw new Error('Debe proporcionar al menos una orden de producción')
+    }
+
+    // Verificar que las OPs existen y no están ya asignadas a otra entrega
+    const ops = await prisma.orden_de_produccion.findMany({
+      where: { cod_op: { in: cod_ops } },
+    })
+
+    if (ops.length !== cod_ops.length) {
+      const encontradas = ops.map(op => op.cod_op)
+      const faltantes = cod_ops.filter(id => !encontradas.includes(id))
+      throw new Error(
+        `Órdenes de producción no encontradas: ${faltantes.join(', ')}`,
+      )
+    }
+
+    const yaAsignadas = ops.filter(
+      op => op.cod_entrega !== null && op.cod_entrega !== cod_entrega,
+    )
+    if (yaAsignadas.length > 0) {
+      throw new Error(
+        `Las siguientes OPs ya están asignadas a otra entrega: ${yaAsignadas.map(op => op.cod_op).join(', ')}`,
+      )
+    }
+
+    return this.entregaRepository.update(cod_entrega, {
+      ordenes_de_produccion: {
+        connect: cod_ops.map(cod_op => ({ cod_op })),
+      },
+    })
+  }
+
+  /**
+   * Desvincula una o varias órdenes de producción de una entrega.
+   * @param cod_entrega - ID de la entrega
+   * @param cod_ops - Array de IDs de órdenes de producción a desvincular
+   */
+  async quitarOrdenesDeProduccion(
+    cod_entrega: number,
+    cod_ops: number[],
+  ): Promise<entrega> {
+    if (!cod_ops || cod_ops.length === 0) {
+      throw new Error('Debe proporcionar al menos una orden de producción')
+    }
+
+    return this.entregaRepository.update(cod_entrega, {
+      ordenes_de_produccion: {
+        disconnect: cod_ops.map(cod_op => ({ cod_op })),
+      },
+    })
+  }
+
   async finalizar(
     cod_entrega: number,
     observaciones?: string,
   ): Promise<entrega> {
-    // Solo actualizamos la entrega y liberamos sus recursos.
-    // Hotfix temporal: Ya NO cerramos la Obra automáticamente aquí, para soportar Entregas Parciales
-    // sin necesidad de alterar el Schema de Prisma actual.
+    const entregaActual = await prisma.entrega.findUnique({
+      where: { cod_entrega },
+      select: { esFinal: true, cod_obra: true },
+    })
+
+    if (!entregaActual) {
+      throw new Error(`Entrega no encontrada (ID: ${cod_entrega})`)
+    }
+
     const [entregaActualizada] = await prisma.$transaction(async tx => {
       const entrega = await tx.entrega.update({
         where: { cod_entrega },
@@ -247,9 +322,13 @@ export class EntregaService {
         data: { fecha_hora_fin_real: new Date() },
       })
 
-      // Se elimina el conteo y la actualización del estado de la Obra.
-      // Así evitamos cerrar la Obra permanentemente en entregas parciales
-      // sin requerir migraciones de base de datos de momento.
+      // Si es la entrega final, cerrar la Obra automáticamente
+      if (entregaActual.esFinal) {
+        await tx.obra.update({
+          where: { cod_obra: entregaActual.cod_obra },
+          data: { estado: 'FINALIZADA' },
+        })
+      }
 
       return [entrega]
     })


### PR DESCRIPTION
## Resumen

Ahora: una entrega puede tener múltiples órdenes de producción (1-a-N), y cada OP pertenece a una sola entrega.


## Cambios Técnicos Implementados
### Base de datos
entrega: se elimina cod_op (FK 1-a-1) y se agrega el campo esFinal Boolean
orden_de_produccion: se agrega cod_entrega Int? como FK nullable hacia entrega, y la relación entrega entrega? @relation(...).

Renombra orden_de_produccion → ordenes_de_produccion en todos los include (refleja la relación 1-a-N).
entrega.service.ts

create: acepta cod_ops?: number[] (array) en lugar de cod_op?: number, y el nuevo campo esFinal?: boolean.

Si esFinal = true, la creación de la entrega y el cierre de la obra (estado: 'ENTREGADA') ocurren en una transacción atómica.

Nuevos métodos: agregarOrdenesDeProduccion(cod_entrega, cod_ops[]) y quitarOrdenesDeProduccion(cod_entrega, cod_ops[]) con validaciones (OP existente, OP no asignada a otra entrega).

---
