### PR TITLE
Refactor/op notas managment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,20 +43,20 @@ model empleado_visita {
 }
 
 model entrega {
-  cod_obra             Int
-  fecha_hora_entrega   DateTime               @db.Timestamp(6)
-  estado               String                 @db.VarChar(50)
-  observaciones        String?                @db.VarChar(500)
-  detalle              String                 @db.VarChar(50)
-  cod_entrega          Int                    @id @default(autoincrement())
-  dias_viaticos        Int?
-  fecha_cancelacion    DateTime?              @db.Date
-  esFinal              Boolean                @default(false)
-  obra                 obra                   @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  cod_obra              Int
+  fecha_hora_entrega    DateTime               @db.Timestamp(6)
+  estado                String                 @db.VarChar(50)
+  observaciones         String?                @db.VarChar(500)
+  detalle               String                 @db.VarChar(50)
+  cod_entrega           Int                    @id @default(autoincrement())
+  dias_viaticos         Int?
+  fecha_cancelacion     DateTime?              @db.Date
+  esFinal               Boolean                @default(false)
+  obra                  obra                   @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  entrega_empleado      entrega_empleado[]
   ordenes_de_produccion orden_de_produccion[]
-  entrega_empleado     entrega_empleado[]
-  uso_maquinaria       uso_maquinaria[]
-  uso_vehiculo_entrega uso_vehiculo_entrega[]
+  uso_maquinaria        uso_maquinaria[]
+  uso_vehiculo_entrega  uso_vehiculo_entrega[]
 }
 
 model entrega_empleado {

--- a/src/models/Entrega/entrega.service.spec.ts
+++ b/src/models/Entrega/entrega.service.spec.ts
@@ -18,11 +18,13 @@ vi.mock('../../shared/db/prismaClient', () => {
     entrega: { update: vi.fn() },
     uso_vehiculo_entrega: { updateMany: vi.fn() },
     uso_maquinaria: { updateMany: vi.fn() },
+    obra: { update: vi.fn() },
   }
 
   return {
     prisma: {
       obra: { findUnique: vi.fn() },
+      entrega: { findUnique: vi.fn() },
       $transaction: vi.fn(async (cb) => {
         // Ejecutamos el callback pasando el "transactor" simulado
         return await cb(mockPrismaTx)
@@ -103,12 +105,21 @@ describe('EntregaService - Pruebas Unitarias', () => {
 
   describe('finalizar()', () => {
     it('debería completar y liberar vehículos y maquinarias mediante la transacción prismática', async () => {
+      vi.mocked(prisma.entrega.findUnique).mockResolvedValue({
+        esFinal: false,
+        cod_obra: 1,
+      } as any)
+
       // Configuramos el comportamiento del prisma mock transaccional
       // Nota: vi.mocked no funciona directo con el parametro del callback si no lo extraemos
       // pero el diseño del mock de vi.mocked arriba ya inyecta el comportamiento de resolucion.
       
       const res = await entregaService.finalizar(100, 'Entregado OK')
       
+      expect(prisma.entrega.findUnique).toHaveBeenCalledWith({
+        where: { cod_entrega: 100 },
+        select: { esFinal: true, cod_obra: true },
+      })
       // La transacción debe haberse llamado
       expect(prisma.$transaction).toHaveBeenCalledOnce()
       // En un entorno de mocks complejos, podríamos interceptar `tx.entrega.update`

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -1,7 +1,14 @@
 import { ObraService } from './obra.service.js'
 import { Request, Response } from 'express'
+import type { NotasFabricaFilters } from './obra.repository.js'
 
 const obraService = new ObraService()
+type NotasFabricaEstado = NotasFabricaFilters['estado']
+const NOTAS_FABRICA_ESTADOS = [
+  'SIN_ORDEN',
+  'EN_PRODUCCION',
+  'FINALIZADA',
+] as const
 
 /**
  * Controlador para manejar las rutas de las obras.
@@ -58,7 +65,7 @@ export class ObraController {
   /** Obtiene todas las obras */
   async getAll(req: Request, res: Response) {
     const obras = await obraService.findAll()
-    res.status(201).json(obras)
+    res.status(200).json(obras)
   }
 
   /** Obtiene una obra por ID (usado internamente) */
@@ -78,21 +85,125 @@ export class ObraController {
 
   // ----------- NOTA DE FÁBRICA -----------
 
+  /** Obtiene obras para Notas de Fábrica según filtros de frontend */
+  async getNotasFabrica(req: Request, res: Response) {
+    try {
+      const { estado, fechaDesde, fechaHasta } = req.query as {
+        estado?: string
+        fechaDesde?: string
+        fechaHasta?: string
+      }
+
+      const allowedQueryParams = new Set(['estado', 'fechaDesde', 'fechaHasta'])
+      const invalidQueryParams = Object.keys(req.query).filter(
+        key => !allowedQueryParams.has(key),
+      )
+
+      if (invalidQueryParams.length > 0) {
+        return res.status(400).json({
+          message:
+            'Parámetros no permitidos. Solo se aceptan estado, fechaDesde y fechaHasta',
+        })
+      }
+
+      const normalizeQueryValue = (value?: string) => {
+        if (!value) return undefined
+        const normalized = value.trim()
+        if (!normalized) return undefined
+        if (normalized === 'undefined' || normalized === 'null') return undefined
+        return normalized
+      }
+
+      const normalizedEstado = normalizeQueryValue(estado)
+      const normalizedFechaDesde = normalizeQueryValue(fechaDesde)
+      const normalizedFechaHasta = normalizeQueryValue(fechaHasta)
+
+      if (!normalizedEstado) {
+        return res.status(400).json({
+          message: 'El query param "estado" es obligatorio',
+        })
+      }
+
+      if (
+        !NOTAS_FABRICA_ESTADOS.includes(normalizedEstado as NotasFabricaEstado)
+      ) {
+        return res.status(400).json({
+          message:
+            'El estado debe ser SIN_ORDEN, EN_PRODUCCION o FINALIZADA',
+        })
+      }
+
+      const fechaDesdeDate = normalizedFechaDesde
+        ? new Date(normalizedFechaDesde)
+        : null
+      const fechaHastaDate = normalizedFechaHasta
+        ? new Date(normalizedFechaHasta)
+        : null
+
+      if (normalizedFechaDesde && Number.isNaN(fechaDesdeDate?.getTime())) {
+        return res.status(400).json({ message: 'fechaDesde inválida' })
+      }
+
+      if (normalizedFechaHasta && Number.isNaN(fechaHastaDate?.getTime())) {
+        return res.status(400).json({ message: 'fechaHasta inválida' })
+      }
+
+      if (
+        fechaDesdeDate &&
+        fechaHastaDate &&
+        fechaDesdeDate.getTime() > fechaHastaDate.getTime()
+      ) {
+        return res.status(400).json({
+          message: 'fechaDesde no puede ser mayor a fechaHasta',
+        })
+      }
+
+      const obras = await obraService.findNotasFabrica({
+        estado: normalizedEstado as NotasFabricaEstado,
+        fechaDesde: normalizedFechaDesde,
+        fechaHasta: normalizedFechaHasta,
+      })
+
+      res.status(200).json(obras)
+    } catch (error) {
+      res.status(500).json({
+        message: 'Error al obtener notas de fábrica',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
   /** Sube nota de fábrica a una obra */
   async subirNotaFabrica(req: Request, res: Response) {
-    const id = parseInt(req.params.id, 10)
+    const codObra = Number.parseInt(req.params.cod_obra, 10)
+
+    if (Number.isNaN(codObra)) {
+      return res.status(400).json({ message: 'Código de obra inválido' })
+    }
+
     if (!req.file) {
       return res.status(400).json({ message: 'No se ha subido ningún archivo' })
     }
-    await obraService.subirNotaFabrica(id, req.file)
-    res.status(201).json({ message: 'Archivo subido correctamente' })
+
+    const obraExistente = await obraService.findById(codObra)
+    if (!obraExistente) {
+      return res.status(404).json({ message: 'Obra no encontrada' })
+    }
+
+    const obra = await obraService.subirNotaFabrica(codObra, req.file)
+    res.status(201).json(obra)
   }
 
   /** Elimina la nota de fábrica de una obra */
   async deleteNotaFabrica(req: Request, res: Response) {
-    const id = parseInt(req.params.id, 10)
-    await obraService.deleteNotaFabrica(id)
-    res.json({ message: 'Nota de fábrica eliminada correctamente' })
+    const codObra = Number.parseInt(req.params.cod_obra, 10)
+
+    if (Number.isNaN(codObra)) {
+      return res.status(400).json({ message: 'Código de obra inválido' })
+    }
+
+    const obra = await obraService.deleteNotaFabrica(codObra)
+    res.status(200).json(obra)
   }
 
   /** Obtiene obras con nota de fábrica y orden en proceso */

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -1,6 +1,17 @@
 import { PrismaClient, obra, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
 
+export type NotasFabricaEstado =
+  | 'SIN_ORDEN'
+  | 'EN_PRODUCCION'
+  | 'FINALIZADA'
+
+export interface NotasFabricaFilters {
+  estado: NotasFabricaEstado
+  fechaDesde?: string
+  fechaHasta?: string
+}
+
 /**
  * Repositorio para acceder a la base de datos de obras.
  */
@@ -136,12 +147,84 @@ export class ObraRepository {
     id: number,
     path: string,
     filename: string,
-  ): Promise<void> {
-    await this.prisma.obra.update({
+  ): Promise<obra> {
+    return await this.prisma.obra.update({
       where: { cod_obra: id },
       data: {
         nota_fabrica: path,
         nota_fabrica_pid: filename,
+      },
+    })
+  }
+
+  async findNotasFabrica(filters: NotasFabricaFilters): Promise<obra[]> {
+    const andConditions: Prisma.obraWhereInput[] = [
+      {
+        OR: [{ nota_fabrica: { not: null } }, { nota_fabrica_pid: { not: null } }],
+      },
+    ]
+
+    if (filters.estado === 'SIN_ORDEN') {
+      andConditions.push({
+        orden_de_produccion: {
+          none: {},
+        },
+      })
+    }
+
+    if (filters.estado === 'EN_PRODUCCION') {
+      andConditions.push({
+        orden_de_produccion: {
+          some: {
+            estado: {
+              not: 'FINALIZADA',
+            },
+          },
+        },
+      })
+      andConditions.push({
+        estado: {
+          notIn: ['FINALIZADA', 'PRODUCCION FINALIZADA'],
+        },
+      })
+    }
+
+    if (filters.estado === 'FINALIZADA') {
+      andConditions.push({ estado: 'PRODUCCION FINALIZADA' })
+    }
+
+    if (filters.fechaDesde || filters.fechaHasta) {
+      const fechaIniFilter: Prisma.DateTimeFilter = {}
+
+      if (filters.fechaDesde) {
+        const fechaDesde = new Date(filters.fechaDesde)
+        fechaIniFilter.gte = fechaDesde
+      }
+
+      if (filters.fechaHasta) {
+        const fechaHasta = new Date(filters.fechaHasta)
+        fechaHasta.setHours(23, 59, 59, 999)
+        fechaIniFilter.lte = fechaHasta
+      }
+
+      andConditions.push({ fecha_ini: fechaIniFilter })
+    }
+
+    return await this.prisma.obra.findMany({
+      where: {
+        AND: andConditions,
+      },
+      orderBy: { cod_obra: 'desc' },
+      include: {
+        cliente: true,
+        arquitecto: true,
+        localidad: {
+          include: {
+            provincia: true,
+          },
+        },
+        presupuesto: true,
+        pago: true,
       },
     })
   }

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -197,13 +197,12 @@ export class ObraRepository {
       const fechaIniFilter: Prisma.DateTimeFilter = {}
 
       if (filters.fechaDesde) {
-        const fechaDesde = new Date(filters.fechaDesde)
+        const fechaDesde = new Date(`${filters.fechaDesde}T00:00:00`)
         fechaIniFilter.gte = fechaDesde
       }
 
       if (filters.fechaHasta) {
-        const fechaHasta = new Date(filters.fechaHasta)
-        fechaHasta.setHours(23, 59, 59, 999)
+        const fechaHasta = new Date(`${filters.fechaHasta}T23:59:59.999`)
         fechaIniFilter.lte = fechaHasta
       }
 

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -184,13 +184,13 @@ export class ObraRepository {
       })
       andConditions.push({
         estado: {
-          notIn: ['FINALIZADA', 'PRODUCCION FINALIZADA'],
+          notIn: ['FINALIZADA'],
         },
       })
     }
 
     if (filters.estado === 'FINALIZADA') {
-      andConditions.push({ estado: 'PRODUCCION FINALIZADA' })
+      andConditions.push({ estado: 'FINALIZADA' })
     }
 
     if (filters.fechaDesde || filters.fechaHasta) {

--- a/src/models/Obra/obra.routes.spec.ts
+++ b/src/models/Obra/obra.routes.spec.ts
@@ -33,7 +33,7 @@ describe('Integration Tests - Obra Routes', () => {
       expect(response.status).toBe(401)
     })
 
-    it('debería devolver 201 y lista de obras', async () => {
+    it('debería devolver 200 y lista de obras', async () => {
       vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue([
         { cod_obra: 1, direccion: 'Calle Falsa 123', estado: 'ACTIVA' } as any,
         { cod_obra: 2, direccion: 'Av. Siempre Viva', estado: 'EN PRODUCCION' } as any,
@@ -43,7 +43,7 @@ describe('Integration Tests - Obra Routes', () => {
         .get('/api/obras')
         .set('Authorization', `Bearer ${token}`)
 
-      expect(response.status).toBe(201) // ObraController.getAll usa res.status(201)
+      expect(response.status).toBe(200)
       expect(response.body).toHaveLength(2)
     })
   })

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -36,47 +36,9 @@ obraRouter.get('/para-pedido-stock', (req, res) => {
   obraController.getObrasParaPedidoStock(req, res)
 })
 
-// Solicitar stock para una obra
-obraRouter.patch('/:id/solicitar-stock', (req, res) => {
-  obraController.solicitarStock(req, res)
-})
-
-// Confirmar recepción de stock
-obraRouter.patch('/:id/recibir-stock', (req, res) => {
-  obraController.recibirStock(req, res)
-})
-
-// ----------- NOTA DE FÁBRICA -----------
-
-// Subir nota de fábrica a una obra
-obraRouter.post('/:id/nota-fabrica', (req, res) => {
-  upload.single('file')(req, res, err => {
-    if (err) {
-      return res
-        .status(400)
-        .json({ message: 'Error al subir el archivo', error: err })
-    }
-    obraController.subirNotaFabrica(req, res)
-  })
-})
-
-// Eliminar nota de fábrica de una obra
-obraRouter.delete('/:id/nota-fabrica', (req, res) => {
-  validate({ params: idParamsSchema })(req, res, async () => {
-    try {
-      const id = parseInt(req.params.id, 10)
-      const obra = await obraController.getOneById(id)
-      if (!obra) {
-        return res.status(404).json({ message: 'Obra no encontrada' })
-      }
-      await deleteUploadedFile(obra.nota_fabrica_pid?.toString() || '')
-      obraController.deleteNotaFabrica(req, res)
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Error desconocido'
-      res.status(500).json({ error: message })
-    }
-  })
+// Obtener obras para Notas de Fábrica con filtros
+obraRouter.get('/notas-fabrica', (req, res) => {
+  obraController.getNotasFabrica(req, res)
 })
 
 // Obtener obras con nota de fábrica sin orden aprobada
@@ -92,6 +54,54 @@ obraRouter.get('/notas-con-orden-proceso', (req, res) => {
 // Obtener obras con presupuesto aceptado
 obraRouter.get('/con-presupuesto-aceptado', (req, res) => {
   obraController.getObrasConPresupuestoAceptado(req, res)
+})
+
+// Solicitar stock para una obra
+obraRouter.patch('/:id/solicitar-stock', (req, res) => {
+  obraController.solicitarStock(req, res)
+})
+
+// Confirmar recepción de stock
+obraRouter.patch('/:id/recibir-stock', (req, res) => {
+  obraController.recibirStock(req, res)
+})
+
+// ----------- NOTA DE FÁBRICA -----------
+
+// Subir nota de fábrica a una obra
+obraRouter.post('/:cod_obra/nota-fabrica', (req, res) => {
+  upload.single('file')(req, res, err => {
+    if (err) {
+      return res
+        .status(400)
+        .json({ message: 'Error al subir el archivo' })
+    }
+    obraController.subirNotaFabrica(req, res)
+  })
+})
+
+// Eliminar nota de fábrica de una obra
+obraRouter.delete('/:cod_obra/nota-fabrica', async (req, res) => {
+  try {
+    const codObra = Number.parseInt(req.params.cod_obra, 10)
+    if (Number.isNaN(codObra)) {
+      return res.status(400).json({ message: 'Código de obra inválido' })
+    }
+
+    const obra = await obraController.getOneById(codObra)
+    if (!obra) {
+      return res.status(404).json({ message: 'Obra no encontrada' })
+    }
+
+    if (obra.nota_fabrica_pid) {
+      await deleteUploadedFile(obra.nota_fabrica_pid.toString())
+    }
+
+    obraController.deleteNotaFabrica(req, res)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error desconocido'
+    res.status(500).json({ message })
+  }
 })
 
 // ----------- CRUD DE OBRAS -----------

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -1,5 +1,8 @@
 import { obra, Prisma } from '@prisma/client'
-import { ObraRepository } from './obra.repository.js'
+import {
+  NotasFabricaFilters,
+  ObraRepository,
+} from './obra.repository.js'
 
 type ObraCreateInputExtended = Prisma.obraCreateInput & {
   cuil?: string
@@ -59,14 +62,22 @@ export class ObraService {
 
   // ----------- NOTA DE FÁBRICA -----------
 
+  /** Obtiene obras para la pantalla de Notas de Fábrica */
+  async findNotasFabrica(filtros: NotasFabricaFilters): Promise<obra[]> {
+    return this.repository.findNotasFabrica(filtros)
+  }
+
   /** Sube nota de fábrica a una obra */
-  async subirNotaFabrica(id: number, file: Express.Multer.File): Promise<void> {
-    await this.repository.subirNotaFabrica(id, file.path, file.filename)
+  async subirNotaFabrica(
+    id: number,
+    file: Express.Multer.File,
+  ): Promise<obra> {
+    return this.repository.subirNotaFabrica(id, file.path, file.filename)
   }
 
   /** Elimina la nota de fábrica de una obra */
-  async deleteNotaFabrica(id: number) {
-    await this.repository.update(id, {
+  async deleteNotaFabrica(id: number): Promise<obra> {
+    return this.repository.update(id, {
       nota_fabrica: null,
       nota_fabrica_pid: null,
     })

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -2,6 +2,7 @@ import { OrdenProduccionService } from './ordenProduccion.service.js'
 import { Request, Response } from 'express'
 
 const ordenService = new OrdenProduccionService()
+const ORDEN_ESTADOS = ['PENDIENTE', 'APROBADA', 'EN PRODUCCION', 'FINALIZADA']
 
 export class OrdenProduccionController {
   async create(req: Request, res: Response) {
@@ -33,7 +34,58 @@ export class OrdenProduccionController {
 
   async getAll(req: Request, res: Response) {
     try {
-      const ordenes = await ordenService.findAll()
+      const { estado, fechaDesde, fechaHasta } = req.query as {
+        estado?: string
+        fechaDesde?: string
+        fechaHasta?: string
+      }
+
+      const allowedQueryParams = new Set(['estado', 'fechaDesde', 'fechaHasta'])
+      const invalidQueryParams = Object.keys(req.query).filter(
+        key => !allowedQueryParams.has(key),
+      )
+
+      if (invalidQueryParams.length > 0) {
+        return res.status(400).json({
+          message:
+            'Parámetros no permitidos. Solo se aceptan estado, fechaDesde y fechaHasta',
+        })
+      }
+
+      if (estado && !ORDEN_ESTADOS.includes(estado)) {
+        return res.status(400).json({
+          message:
+            'El estado debe ser PENDIENTE, APROBADA, EN PRODUCCION o FINALIZADA',
+        })
+      }
+
+      const fechaDesdeDate = fechaDesde ? new Date(fechaDesde) : null
+      const fechaHastaDate = fechaHasta ? new Date(fechaHasta) : null
+
+      if (fechaDesde && Number.isNaN(fechaDesdeDate?.getTime())) {
+        return res.status(400).json({ message: 'fechaDesde inválida' })
+      }
+
+      if (fechaHasta && Number.isNaN(fechaHastaDate?.getTime())) {
+        return res.status(400).json({ message: 'fechaHasta inválida' })
+      }
+
+      if (
+        fechaDesdeDate &&
+        fechaHastaDate &&
+        fechaDesdeDate.getTime() > fechaHastaDate.getTime()
+      ) {
+        return res.status(400).json({
+          message: 'fechaDesde no puede ser mayor a fechaHasta',
+        })
+      }
+
+      const ordenes = await ordenService.findAll({
+        estado,
+        fechaDesde,
+        fechaHasta,
+      })
+
       res.status(200).json(ordenes)
     } catch (error) {
       console.error('Error al obtener órdenes:', error)
@@ -48,17 +100,15 @@ export class OrdenProduccionController {
 
   async getOne(req: Request, res: Response) {
     try {
-      const cod_orden = parseInt(req.params.cod_orden, 10)
+      const cod_op = parseInt(req.params.cod_op, 10)
 
-      if (isNaN(cod_orden)) {
+      if (isNaN(cod_op)) {
         return res.status(400).json({ message: 'Código de orden inválido' })
       }
 
-      const orden = await ordenService.findById(cod_orden)
+      const orden = await ordenService.findById(cod_op)
       if (!orden) {
-        return res
-          .status(404)
-          .json({ message: 'Orden de producción no encontrada' })
+        return res.status(404).json({ message: 'Not found' })
       }
       res.status(200).json(orden)
     } catch (error) {
@@ -74,21 +124,30 @@ export class OrdenProduccionController {
 
   async update(req: Request, res: Response) {
     try {
-      const cod_orden = parseInt(req.params.cod_orden, 10)
+      const cod_op = parseInt(req.params.cod_op, 10)
 
-      if (isNaN(cod_orden)) {
+      if (isNaN(cod_op)) {
         return res.status(400).json({ message: 'Código de orden inválido' })
       }
 
       // Verificar que la orden existe
-      const ordenExistente = await ordenService.findById(cod_orden)
+      const ordenExistente = await ordenService.findById(cod_op)
       if (!ordenExistente) {
         return res
           .status(404)
           .json({ message: 'Orden de producción no encontrada' })
       }
 
-      const orden = await ordenService.update(cod_orden, req.body)
+      const body = { ...req.body }
+      if (typeof body.fecha_validacion === 'string') {
+        const parsedDate = new Date(body.fecha_validacion)
+        if (Number.isNaN(parsedDate.getTime())) {
+          return res.status(400).json({ message: 'fecha_validacion inválida' })
+        }
+        body.fecha_validacion = parsedDate
+      }
+
+      const orden = await ordenService.update(cod_op, body)
       res.status(200).json(orden)
     } catch (error) {
       console.error('Error al actualizar orden:', error)
@@ -103,13 +162,13 @@ export class OrdenProduccionController {
 
   async remove(req: Request, res: Response) {
     try {
-      const cod_orden = parseInt(req.params.cod_orden, 10)
+      const cod_op = parseInt(req.params.cod_op, 10)
 
-      if (isNaN(cod_orden)) {
+      if (isNaN(cod_op)) {
         return res.status(400).json({ message: 'Código de orden inválido' })
       }
 
-      const orden = await ordenService.remove(cod_orden)
+      const orden = await ordenService.remove(cod_op)
       res.status(200).json(orden)
     } catch (error) {
       console.error('Error al eliminar orden:', error)
@@ -200,6 +259,12 @@ export class OrdenProduccionController {
       }
 
       await ordenService.finalizarProduccion(cod_op)
+
+      const { ObraService } = await import('../Obra/obra.service.js')
+      const obraService = new ObraService()
+      await obraService.update(orden.cod_obra, {
+        estado: 'PRODUCCION FINALIZADA',
+      })
 
       res.json({ message: 'Producción finalizada correctamente' })
     } catch (error) {

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -1,6 +1,12 @@
 import { PrismaClient, orden_de_produccion, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
 
+export interface OrdenProduccionFilters {
+  estado?: string
+  fechaDesde?: string
+  fechaHasta?: string
+}
+
 export class OrdenProduccionRepository {
   private prisma: PrismaClient
 
@@ -16,8 +22,31 @@ export class OrdenProduccionRepository {
     })
   }
 
-  async findAll(): Promise<orden_de_produccion[]> {
+  async findAll(filters?: OrdenProduccionFilters): Promise<orden_de_produccion[]> {
+    const andConditions: Prisma.orden_de_produccionWhereInput[] = []
+
+    if (filters?.estado) {
+      andConditions.push({ estado: filters.estado })
+    }
+
+    if (filters?.fechaDesde || filters?.fechaHasta) {
+      const fechaConfeccionFilter: Prisma.DateTimeFilter = {}
+
+      if (filters.fechaDesde) {
+        fechaConfeccionFilter.gte = new Date(filters.fechaDesde)
+      }
+
+      if (filters.fechaHasta) {
+        const fechaHasta = new Date(filters.fechaHasta)
+        fechaHasta.setHours(23, 59, 59, 999)
+        fechaConfeccionFilter.lte = fechaHasta
+      }
+
+      andConditions.push({ fecha_confeccion: fechaConfeccionFilter })
+    }
+
     return await this.prisma.orden_de_produccion.findMany({
+      where: andConditions.length ? { AND: andConditions } : undefined,
       orderBy: { fecha_confeccion: 'desc' },
       include: {
         obra: {

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -33,12 +33,12 @@ export class OrdenProduccionRepository {
       const fechaConfeccionFilter: Prisma.DateTimeFilter = {}
 
       if (filters.fechaDesde) {
-        fechaConfeccionFilter.gte = new Date(filters.fechaDesde)
+        const fechaDesde = new Date(`${filters.fechaDesde}T00:00:00`)
+        fechaConfeccionFilter.gte = fechaDesde
       }
 
       if (filters.fechaHasta) {
-        const fechaHasta = new Date(filters.fechaHasta)
-        fechaHasta.setHours(23, 59, 59, 999)
+        const fechaHasta = new Date(`${filters.fechaHasta}T23:59:59.999`)
         fechaConfeccionFilter.lte = fechaHasta
       }
 

--- a/src/models/OrdenProduccion/ordenProduccion.routes.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.routes.ts
@@ -24,18 +24,6 @@ ordenProduccionRouter.post('/',
   }
 )
 
-ordenProduccionRouter.get('/:cod_orden', (req, res) => {
-  ordenProduccionController.getOne(req, res)
-})
-
-ordenProduccionRouter.put('/:cod_orden', (req, res) => {
-  ordenProduccionController.update(req, res)
-})
-
-ordenProduccionRouter.delete('/:cod_orden', (req, res) => {
-  ordenProduccionController.remove(req, res)
-})
-
 ordenProduccionRouter.get('/obra/:cod_obra/finalizada', (req, res) => {
   ordenProduccionController.getByObraAndFinalizada(req, res)
 })
@@ -50,6 +38,18 @@ ordenProduccionRouter.post('/:cod_op/iniciar', (req, res) => {
 
 ordenProduccionRouter.post('/:cod_op/finalizar', (req, res) => {
   ordenProduccionController.finalizarProduccion(req, res)
+})
+
+ordenProduccionRouter.get('/:cod_op', (req, res) => {
+  ordenProduccionController.getOne(req, res)
+})
+
+ordenProduccionRouter.put('/:cod_op', (req, res) => {
+  ordenProduccionController.update(req, res)
+})
+
+ordenProduccionRouter.delete('/:cod_op', (req, res) => {
+  ordenProduccionController.remove(req, res)
 })
 
 export default ordenProduccionRouter

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -1,5 +1,8 @@
 import { orden_de_produccion, Prisma } from '@prisma/client'
-import { OrdenProduccionRepository } from './ordenProduccion.repository.js'
+import {
+  OrdenProduccionFilters,
+  OrdenProduccionRepository,
+} from './ordenProduccion.repository.js'
 import { prisma } from '../../shared/db/prismaClient.js'
 
 export class OrdenProduccionService {
@@ -28,8 +31,10 @@ export class OrdenProduccionService {
     return await this.repository.create(prismaData)
   }
 
-  async findAll(): Promise<orden_de_produccion[]> {
-    return this.repository.findAll()
+  async findAll(
+    filters?: OrdenProduccionFilters,
+  ): Promise<orden_de_produccion[]> {
+    return this.repository.findAll(filters)
   }
 
   async findById(cod_op: number): Promise<orden_de_produccion | null> {


### PR DESCRIPTION
### Resumen
Este PR estabiliza el flujo de Notas de Fábrica y Órdenes de Producción, simplificando filtros y corrigiendo inconsistencias de fecha/estado entre frontend y backend.
También deja validadas las rutas y tests críticos para evitar regresiones.

---

### Cambios Técnicos Implementados
- Se simplificaron filtros en listados para usar solo:
  - estado
  - fechaDesde
  - fechaHasta
- Se validaron y normalizaron query params en controladores para evitar parámetros no permitidos.
- Se corrigió la lógica de filtrado por fecha en:
  - Notas de Fábrica (por fecha de inicio de obra)
  - Órdenes de Producción (por fecha de confección)
- Se ajustó la lógica de estados para que la clasificación de Notas (SIN_ORDEN / EN_PRODUCCION / FINALIZADA) sea consistente.
- Se corrigieron mocks en tests de EntregaService para evitar fallos por llamadas Prisma nuevas (findUnique).
- Se verificó estabilidad general con pruebas:
  - pnpm test
  - vitest de módulos afectados

---

### Guía para Pruebas y Revisión
1. Ejecutar `pnpm test` y verificar suite completa en verde.
2. Probar endpoint de notas:
   - `GET /api/obras/notas-fabrica?estado=EN_PRODUCCION&fechaDesde=2026-03-27&fechaHasta=2026-04-30`
   - Confirmar que respete estado y rango de fechas.
3. Probar endpoint de órdenes:
   - `GET /api/ordenes-produccion?estado=EN%20PRODUCCION&fechaDesde=2026-04-01&fechaHasta=2026-04-30`
   - Confirmar que no incluya fechas fuera de rango.
4. Caso borde:
   - enviar solo `fechaDesde`
   - enviar solo `fechaHasta`
   - enviar fecha inválida
   - esperado: filtrado correcto o 400 con mensaje claro.

---

### Screenshots (Opcional)
N/A (cambios backend)