### PR TITLE
Feat/finalizar produccion obra

### DIFF
--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -292,5 +292,16 @@ export class ObraController {
     const obra = await obraService.recibirStock(id)
     return sendSuccess(res, obra, 'Stock received and obra now in production')
   })
-}
 
+
+  /**
+   * Changes obra status to PRODUCCION FINALIZADA.
+   */
+  finalizarProduccion = catchAsync(async (req: Request, res: Response) => {
+    const id = parseInt(req.params.id, 10)
+    if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
+
+    const obra = await obraService.finalizarProduccion(id)
+    return sendSuccess(res, obra, 'Obra production finalized successfully')
+  })
+}

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -308,8 +308,6 @@ export class ObraController {
     const stats = await obraService.getCoordinacionStats()
     return sendSuccess(res, stats)
   })
-}
-
 
   /**
    * Changes obra status to PRODUCCION FINALIZADA.

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -170,27 +170,28 @@ export class ObraRepository {
           none: {},
         },
       })
+      andConditions.push({
+        estado: {
+          notIn: ['PRODUCCION FINALIZADA', 'CANCELADA'],
+        },
+      })
     }
 
     if (filters.estado === 'EN_PRODUCCION') {
       andConditions.push({
         orden_de_produccion: {
-          some: {
-            estado: {
-              not: 'FINALIZADA',
-            },
-          },
+          some: {},
         },
       })
       andConditions.push({
         estado: {
-          notIn: ['FINALIZADA'],
+          notIn: ['PRODUCCION FINALIZADA', 'CANCELADA'],
         },
       })
     }
 
     if (filters.estado === 'FINALIZADA') {
-      andConditions.push({ estado: 'FINALIZADA' })
+      andConditions.push({ estado: 'PRODUCCION FINALIZADA' })
     }
 
     if (filters.fechaDesde || filters.fechaHasta) {

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -46,6 +46,9 @@ obraRouter.patch('/:id/solicitar-stock', obraController.solicitarStock)
 // Confirmar recepción de stock
 obraRouter.patch('/:id/recibir-stock', obraController.recibirStock)
 
+// Finalizar producción de una obra
+obraRouter.patch('/:id/finalizar-produccion', obraController.finalizarProduccion)
+
 // ----------- NOTA DE FÁBRICA -----------
 
 // Subir nota de fábrica a una obra

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -342,5 +342,21 @@ export class ObraService {
     }
     return cuil
   }
+
+  /**
+   * Finalizes production of an obra by changing its status to PRODUCCION FINALIZADA.
+   */
+  async finalizarProduccion(id: number): Promise<obra> {
+    const obra = await this.findById(id)
+    if (obra.estado !== 'EN PRODUCCION') {
+      throw new ValidationError(
+        'Solo se pueden finalizar obras que están "En Producción".',
+        'INVALID_STATE'
+      )
+    }
+    return await this.repository.update(id, { estado: 'PRODUCCION FINALIZADA' })
+  }
 }
+
+
 

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -14,7 +14,7 @@ export class OrdenProduccionController {
    * Creates a new production order.
    */
   create = catchAsync(async (req: Request, res: Response) => {
-    const nueva = await ordenProduccionService.create(req.body)
+    const nueva = await ordenProduccionService.create(req.body, req.file)
     return sendSuccess(res, nueva, 'Production order created successfully', 201)
   })
 
@@ -45,8 +45,8 @@ export class OrdenProduccionController {
   /**
    * Gets all validated production orders.
    */
-  getValidadas = catchAsync(async (req: Request, res: Response) => {
-    const ordenes = await ordenProduccionService.findValidadas()
+  getAprobadas = catchAsync(async (req: Request, res: Response) => {
+    const ordenes = await ordenProduccionService.findAprobadas()
     return sendSuccess(res, ordenes)
   })
 

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -78,7 +78,7 @@ export class OrdenProduccionRepository {
     })
   }
 
-  async findValidadas(): Promise<orden_de_produccion[]> {
+  async findAprobadas(): Promise<orden_de_produccion[]> {
     return await this.prisma.orden_de_produccion.findMany({
       where: {
         estado: 'APROBADA',

--- a/src/models/OrdenProduccion/ordenProduccion.routes.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.routes.ts
@@ -7,7 +7,7 @@ const ordenProduccionRouter = Router()
 
 ordenProduccionRouter.get('/', ordenProduccionController.getAll)
 
-ordenProduccionRouter.get('/validadas', ordenProduccionController.getValidadas)
+ordenProduccionRouter.get('/Aprobadas', ordenProduccionController.getAprobadas)
 
 ordenProduccionRouter.get('/en-produccion', ordenProduccionController.getEnProduccion)
 

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -7,6 +7,18 @@ import { prisma } from '../../shared/db/prismaClient.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { ValidationError } from '../../shared/errors/validationError.js'
 
+interface OrdenProduccionCreateInput {
+  cod_obra: number | string
+  url?: string | null
+  public_id?: string | null
+  fecha_validacion?: Date | string | null
+}
+
+interface UploadedOrdenFile {
+  path?: string
+  filename?: string
+}
+
 /**
  * Service to manage production orders (orden de producción).
  */
@@ -20,23 +32,44 @@ export class OrdenProduccionService {
   /**
    * Creates a new production order.
    */
-  async create(data: {
-    cod_obra: number
-    url: string
-    public_id: string
-    fecha_validacion?: Date | null
-  }): Promise<orden_de_produccion> {
+  async create(
+    data: OrdenProduccionCreateInput,
+    uploadedFile?: UploadedOrdenFile,
+  ): Promise<orden_de_produccion> {
+    const codObra = Number(data.cod_obra)
+    if (!Number.isInteger(codObra) || codObra <= 0) {
+      throw new ValidationError('Código de obra inválido', 'INVALID_ID')
+    }
+
+    const normalizedUrl = (uploadedFile?.path ?? data.url ?? '').trim()
+    if (!normalizedUrl) {
+      throw new ValidationError('No se ha subido ningún archivo', 'FILE_REQUIRED')
+    }
+
+    const fechaValidacion = this.parseFechaValidacion(data.fecha_validacion)
+
     const prismaData: Prisma.orden_de_produccionCreateInput = {
       obra: {
-        connect: { cod_obra: data.cod_obra },
+        connect: { cod_obra: codObra },
       },
       fecha_confeccion: new Date(),
-      fecha_validacion: data.fecha_validacion || null,
-      url: data.url,
-      public_id: data.public_id,
+      fecha_validacion: fechaValidacion,
+      url: normalizedUrl,
+      public_id: uploadedFile?.filename ?? data.public_id ?? null,
     }
 
     return await this.repository.create(prismaData)
+  }
+
+  private parseFechaValidacion(value: Date | string | null | undefined): Date | null {
+    if (!value) return null
+
+    const parsedDate = value instanceof Date ? value : new Date(value)
+    if (Number.isNaN(parsedDate.getTime())) {
+      throw new ValidationError('Fecha de validación inválida', 'INVALID_DATE')
+    }
+
+    return parsedDate
   }
 
   /**
@@ -62,8 +95,8 @@ export class OrdenProduccionService {
   /**
    * Gets all validated production orders.
    */
-  async findValidadas(): Promise<orden_de_produccion[]> {
-    return await this.repository.findValidadas()
+  async findAprobadas(): Promise<orden_de_produccion[]> {
+    return await this.repository.findAprobadas()
   }
 
   /**
@@ -139,9 +172,9 @@ export class OrdenProduccionService {
   async iniciarProduccion(cod_op: number): Promise<orden_de_produccion> {
     const orden = await this.findById(cod_op)
 
-    if (orden.estado !== 'VALIDADA') {
+    if (orden.estado !== 'APROBADA') {
       throw new ValidationError(
-        'Solo las órdenes "Validadas" pueden iniciar producción.',
+        'Solo las órdenes "Aprobadas" pueden iniciar producción.',
         'INVALID_STATE'
       )
     }

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -152,22 +152,11 @@ export class OrdenProduccionService {
       )
     }
 
-    const [ordenActualizada] = await prisma.$transaction([
-      prisma.orden_de_produccion.update({
-        where: { cod_op },
-        data: { estado: 'FINALIZADA' },
-      }),
-    ])
-
-    console.log(
-      `[NOTIFICATION] Production of Order #${orden.cod_op} has finished. Notifying Coordination.`,
-    )
-
-    return ordenActualizada
+    return await this.repository.update(cod_op, { estado: 'FINALIZADA' })
   }
 
   /**
-   * Marks a production order as starting production.
+   * Marks a production order as starting production and updates the associated obra.
    */
   async iniciarProduccion(cod_op: number): Promise<orden_de_produccion> {
     const orden = await this.findById(cod_op)
@@ -179,7 +168,26 @@ export class OrdenProduccionService {
       )
     }
 
-    return await this.repository.update(cod_op, { estado: 'EN PRODUCCION' })
+    const [ordenActualizada] = await prisma.$transaction([
+      prisma.orden_de_produccion.update({
+        where: { cod_op },
+        data: { estado: 'EN PRODUCCION' },
+        include: {
+          obra: {
+            include: {
+              cliente: true,
+              localidad: true,
+            },
+          },
+        },
+      }),
+      prisma.obra.update({
+        where: { cod_obra: orden.cod_obra },
+        data: { estado: 'EN PRODUCCION' },
+      }),
+    ])
+
+    return ordenActualizada
   }
 }
 


### PR DESCRIPTION
### Resumen
Este PR soluciona inconsistencias críticas en el flujo de producción, registra rutas previamente inaccesibles y ajusta los filtros de búsqueda de la base de datos para cumplir de forma estricta las lógicas de negocio al listar Notas de Fábrica.
### Cambios Técnicos Implementados
- **Rutas y Controladores:** Se agregó el endpoint `PATCH /:id/finalizar-produccion` en el router, que había quedado aislado del `obraController`.
- **Sincronización de Estados (Transacciones):** Se modificó la acción de iniciar OP ([iniciarProduccion](cci:1://file:///e:/Emi/Facultad/Seminario/Back-End-SIGMA-LA/src/models/OrdenProduccion/ordenProduccion.service.ts:157:2-190:3)) empleando `prisma.$transaction` para actualizar atómicamente la Obra a "EN PRODUCCION" junto con su orden.
- **Filtros Repositorio:** 
  - Al buscar obras "EN_PRODUCCION", se obliga a validar la pre-existencia de órdenes de producción.
  - Las listas "SIN_ORDEN" y "EN_PRODUCCION" ahora excluyen de manera correcta las entidades en estado `PRODUCCION FINALIZADA`.