### PR TITLE
Refactor: Arquitectura de estadísticas basada en Domain-Driven Design y tipado estricto

### DIFF
--- a/src/models/Entrega/entrega.controller.ts
+++ b/src/models/Entrega/entrega.controller.ts
@@ -102,5 +102,11 @@ export class EntregaController {
     )
     return sendSuccess(res, entrega, 'Órdenes de producción quitadas exitosamente')
   })
+
+  // ----------- STATS -----------
+  getProgresoDiario = catchAsync(async (req: Request, res: Response) => {
+    const stats = await entregaService.getProgresoDiario()
+    return sendSuccess(res, stats)
+  })
 }
 

--- a/src/models/Entrega/entrega.routes.ts
+++ b/src/models/Entrega/entrega.routes.ts
@@ -7,6 +7,8 @@ const entregaRouter = Router()
 
 entregaRouter.get('/', entregaController.getAll)
 
+entregaRouter.get('/stats/progreso-diario', entregaController.getProgresoDiario)
+
 entregaRouter.get('/:cuil_empleado/:estado', entregaController.getEntregasByEmpleadoEstado)
 
 entregaRouter.post('/', entregaController.create)

--- a/src/models/Entrega/entrega.service.ts
+++ b/src/models/Entrega/entrega.service.ts
@@ -344,5 +344,32 @@ export class EntregaService {
       return updated
     }))
   }
+
+  /**
+   * Obtiene estadísticas de entregas programadas y completadas para hoy.
+   */
+  async getProgresoDiario(): Promise<{ agendaHoyEntregas: number; completadosHoyEntregas: number }> {
+    const todayStart = new Date()
+    todayStart.setHours(0, 0, 0, 0)
+
+    const todayEnd = new Date()
+    todayEnd.setHours(23, 59, 59, 999)
+
+    const agendaHoyEntregas = await prisma.entrega.count({
+      where: {
+        fecha_hora_entrega: { gte: todayStart, lte: todayEnd },
+        estado: { not: 'CANCELADO' },
+      },
+    })
+
+    const completadosHoyEntregas = await prisma.entrega.count({
+      where: {
+        fecha_hora_entrega: { gte: todayStart, lte: todayEnd },
+        estado: 'ENTREGADO',
+      },
+    })
+
+    return { agendaHoyEntregas, completadosHoyEntregas }
+  }
 }
 

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -292,5 +292,21 @@ export class ObraController {
     const obra = await obraService.recibirStock(id)
     return sendSuccess(res, obra, 'Stock received and obra now in production')
   })
+
+  // ----------- STATS -----------
+  getAdminStats = catchAsync(async (req: Request, res: Response) => {
+    const stats = await obraService.getAdminStats()
+    return sendSuccess(res, stats)
+  })
+
+  getVentasStats = catchAsync(async (req: Request, res: Response) => {
+    const stats = await obraService.getVentasStats()
+    return sendSuccess(res, stats)
+  })
+
+  getCoordinacionStats = catchAsync(async (req: Request, res: Response) => {
+    const stats = await obraService.getCoordinacionStats()
+    return sendSuccess(res, stats)
+  })
 }
 

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -10,6 +10,11 @@ const obraController = new ObraController()
 const obraRouter = Router()
 
 // ----------- FILTROS Y BÚSQUEDAS -----------
+// Stats endpoints (must be before /:id routes)
+obraRouter.get('/stats/admin', obraController.getAdminStats)
+obraRouter.get('/stats/ventas', obraController.getVentasStats)
+obraRouter.get('/stats/coordinacion', obraController.getCoordinacionStats)
+
 // Obtener todas las obras
 obraRouter.get('/', obraController.getAll)
 

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -5,6 +5,7 @@ import {
 } from './obra.repository.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { ValidationError } from '../../shared/errors/validationError.js'
+import { prisma } from '../../shared/db/prismaClient.js'
 
 type ObraCreateInputExtended = Prisma.obraCreateInput & {
   cuil?: string
@@ -331,6 +332,96 @@ export class ObraService {
       throw new ValidationError('Esta obra no está esperando stock.', 'INVALID_STATE')
     }
     return await this.repository.update(id, { estado: 'EN PRODUCCION' })
+  }
+
+  /**
+   * Formats CUIL with hyphens (e.g., 20-12345678-9).
+   */
+  /**
+   * Obtiene la deuda total sumando presupuestos descontando pagos.
+   */
+  async getCuentasPorCobrar(): Promise<number> {
+    const obrasPendientes = await prisma.obra.findMany({
+      where: {
+        estado: { in: ['PAGADA PARCIALMENTE', 'EN ESPERA DE PAGO'] },
+      },
+      include: {
+        presupuesto: {
+          where: { fecha_aceptacion: { not: null } },
+        },
+        pago: true,
+      },
+    })
+
+    let cuentasPorCobrar = 0
+    for (const ob of obrasPendientes) {
+      const presupuestoAceptado = ob.presupuesto[ob.presupuesto.length - 1]
+      if (presupuestoAceptado) {
+        const totalPagado = ob.pago.reduce(
+          (sum: number, pago: { monto: number }) => sum + Number(pago.monto),
+          0,
+        )
+        const deuda = Number(presupuestoAceptado.valor) - totalPagado
+        if (deuda > 0) cuentasPorCobrar += deuda
+      }
+    }
+    return cuentasPorCobrar
+  }
+
+  /**
+   * Obtiene estadísticas de obras para el dashboard de Administrador.
+   */
+  async getAdminStats(): Promise<{ obrasActivas: number; nuevasObrasDelMes: number; cuentasPorCobrar: number }> {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const obrasActivas = await prisma.obra.count({
+      where: { estado: { notIn: ['ENTREGADA', 'CANCELADA'] } },
+    })
+
+    const nuevasObrasDelMes = await prisma.obra.count({
+      where: {
+        fecha_ini: { gte: startOfMonth, lte: endOfMonth },
+      },
+    })
+
+    const cuentasPorCobrar = await this.getCuentasPorCobrar()
+
+    return { obrasActivas, nuevasObrasDelMes, cuentasPorCobrar }
+  }
+
+  /**
+   * Obtiene estadísticas de obras para el dashboard de Ventas.
+   */
+  async getVentasStats(): Promise<{ totalPorCobrar: number; obrasGanadasMes: number; obrasFaltaStock: number }> {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const totalPorCobrar = await this.getCuentasPorCobrar()
+
+    const obrasGanadasMes = await prisma.obra.count({
+      where: {
+        fecha_ini: { gte: startOfMonth, lte: endOfMonth },
+      },
+    })
+
+    const obrasFaltaStock = await prisma.obra.count({
+      where: { estado: 'EN ESPERA DE STOCK' },
+    })
+
+    return { totalPorCobrar, obrasGanadasMes, obrasFaltaStock }
+  }
+
+  /**
+   * Obtiene estadísticas de obras para el dashboard de Coordinación.
+   */
+  async getCoordinacionStats(): Promise<{ listasParaEntregar: number }> {
+    const listasParaEntregar = await prisma.obra.count({
+      where: { estado: 'PRODUCCION FINALIZADA' },
+    })
+    return { listasParaEntregar }
   }
 
   /**

--- a/src/models/Pago/pago.controller.ts
+++ b/src/models/Pago/pago.controller.ts
@@ -22,6 +22,11 @@ export class PagoController {
     return sendSuccess(res, nuevoPago, 'Payment registered successfully', 201)
   })
 
+  getFacturacionStats = catchAsync(async (req: Request, res: Response) => {
+    const stats = await pagoService.getFacturacionStats()
+    return sendSuccess(res, stats)
+  })
+
   /**
    * Gets all payments with optional filtering.
    */

--- a/src/models/Pago/pago.routes.ts
+++ b/src/models/Pago/pago.routes.ts
@@ -11,6 +11,7 @@ const pagoController = new PagoController()
 const pagoRouter = Router()
 
 pagoRouter.get('/', pagoController.getAll)
+pagoRouter.get('/stats/facturacion', pagoController.getFacturacionStats)
 
 pagoRouter.post('/', validate({ body: createPagoSchema }), pagoController.create)
 

--- a/src/models/Pago/pago.service.ts
+++ b/src/models/Pago/pago.service.ts
@@ -215,5 +215,52 @@ export class PagoService {
   async findByObra(cod_obra: number): Promise<pago[]> {
     return await this.repository.findManyByObra(cod_obra)
   }
+
+  /**
+   * Retrieves billing statistics for the current and previous month.
+   */
+  async getFacturacionStats(): Promise<{ ingresosMes: number; ingresosMesPasado: number; porcentajeCrecimiento: number }> {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+
+    const startOfPrevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    const endOfPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999)
+
+    const ingresosMesAggregate = await prisma.pago.aggregate({
+      where: {
+        fecha_pago: {
+          gte: startOfMonth,
+          lte: endOfMonth,
+        },
+      },
+      _sum: { monto: true },
+    })
+    const ingresosMes = Number(ingresosMesAggregate._sum.monto || 0)
+
+    const ingresosMesPrevAggregate = await prisma.pago.aggregate({
+      where: {
+        fecha_pago: {
+          gte: startOfPrevMonth,
+          lte: endOfPrevMonth,
+        },
+      },
+      _sum: { monto: true },
+    })
+    const ingresosMesPasado = Number(ingresosMesPrevAggregate._sum.monto || 0)
+    
+    let porcentajeCrecimiento = 0
+    if (ingresosMesPasado > 0) {
+      porcentajeCrecimiento = ((ingresosMes - ingresosMesPasado) / ingresosMesPasado) * 100
+    } else if (ingresosMes > 0) {
+      porcentajeCrecimiento = 100
+    }
+
+    return {
+      ingresosMes,
+      ingresosMesPasado,
+      porcentajeCrecimiento: Math.round(porcentajeCrecimiento * 10) / 10,
+    }
+  }
 }
 

--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -139,6 +139,12 @@ export class VisitaController {
     const visita = await visitaService.cancelar(Number(id), motivo)
     return sendSuccess(res, visita, 'Visit cancelled successfully')
   })
+
+  // ----------- STATS -----------
+  getProgresoDiario = catchAsync(async (req: Request, res: Response) => {
+    const stats = await visitaService.getProgresoDiario()
+    return sendSuccess(res, stats)
+  })
 }
 
 export const visitaController = new VisitaController()

--- a/src/models/Visita/visita.routes.ts
+++ b/src/models/Visita/visita.routes.ts
@@ -8,6 +8,8 @@ const visitaRouter = Router()
 
 visitaRouter.get('/', visitaController.getAll)
 
+visitaRouter.get('/stats/progreso-diario', visitaController.getProgresoDiario)
+
 visitaRouter.post('/', visitaController.create)
 
 visitaRouter.get('/buscar', visitaController.buscar)

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -6,6 +6,7 @@ import { ValidationError } from '../../shared/errors/validationError.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { emailService } from '../../shared/providers/email/index.js'
 import { notificationConfigRepository } from '../../shared/providers/email/NotificationConfigRepository.js'
+import { prisma } from '../../shared/db/prismaClient.js'
 
 /**
  * Interface for creating a new Visita.
@@ -445,7 +446,35 @@ export class VisitaService {
 
     return await this.visitaRepository.update(cod_visita, updateData)
   }
+
+  /**
+   * Obtiene estadísticas de visitas programadas y completadas para hoy.
+   */
+  async getProgresoDiario(): Promise<{ agendaHoyVisitas: number; completadosHoyVisitas: number }> {
+    const todayStart = new Date()
+    todayStart.setHours(0, 0, 0, 0)
+
+    const todayEnd = new Date()
+    todayEnd.setHours(23, 59, 59, 999)
+
+    const agendaHoyVisitas = await prisma.visita.count({
+      where: {
+        fecha_hora_visita: { gte: todayStart, lte: todayEnd },
+        estado: { not: 'CANCELADA' },
+      },
+    })
+
+    const completadosHoyVisitas = await prisma.visita.count({
+      where: {
+        fecha_hora_visita: { gte: todayStart, lte: todayEnd },
+        estado: 'COMPLETADA',
+      },
+    })
+
+    return { agendaHoyVisitas, completadosHoyVisitas }
+  }
 }
+
 
 export const visitaService = new VisitaService()
 


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
-->
Este PR refactoriza por completo el módulo de estadísticas de los dashboards para descentralizar los cálculos adoptando un enfoque DDD (Domain-Driven Design), a la par que se alcanza un tipado fuerte eliminando los usos de `any`.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
-->
- **Arquitectura:** Se eliminó por completo el módulo aglomerado `DashboardStats`, migrando la agregación de métricas de negocio hacia sus propios dominios correspondientes (`Pago`, `Obra`, `Visita`, `Entrega`).
- **Nuevos Endpoints Desacoplados:** Se expusieron las estadísticas a través de endpoints locales por módulo, como `/api/pagos/stats/facturacion` o `/api/entregas/stats/progreso-diario`.
- **Tipado Estricto de TypeScript:** Se erradicaron casteos inseguros. Se aseguró el uso de interfaces de *Prisma* e inferencias nativas para manejar el 100% del código de este ciclo sin incluir ningún tipo `any`.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
-->
1. Iniciar el servidor backend (`pnpm start:dev`).
2. Obtener un token JWT válido (loguearse como Admin, por ejemplo).
3. Consumir los nuevos endpoints de métricas (ej. `GET /api/obras/stats/admin` o `GET /api/visitas/stats/progreso-diario`) y verificar el tiempo de respuesta y la precisión de la agregación de datos.
4. **Verificar Ausencia de Legacy:** Probar acceder a las antiguas rutas `/api/dashboard/...` esperando recibir un error 404 clásico del router debido a su exitosa remoción.