### PR TITLE
Feat: implement pagination

### DIFF
--- a/src/models/Cliente/cliente.controller.ts
+++ b/src/models/Cliente/cliente.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express'
 import { ClienteService } from './cliente.service.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
-import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
+import { parsePagination } from '../../shared/utils/parsePagination.js'
 import { AppError } from '../../shared/errors/AppError.js'
 
 const clienteService = new ClienteService()
@@ -16,30 +17,17 @@ export class ClienteController {
   })
 
   getAll = catchAsync(async (req: Request, res: Response) => {
-    const clientes = await clienteService.findAll()
-    return sendSuccess(res, clientes)
+    const q = req.query.q as string | undefined
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+
+    const result = await clienteService.findAll(q, pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   getOne = catchAsync(async (req: Request, res: Response) => {
     const cuil = req.params.cuil
     const cliente = await clienteService.findById(cuil)
     return sendSuccess(res, cliente)
-  })
-
-  buscar = catchAsync(async (req: Request, res: Response) => {
-    const q = String(req.query.q ?? '').trim()
-    const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10))
-    const pageSize = Math.max(
-      1,
-      Math.min(100, parseInt(String(req.query.pageSize ?? '25'), 10)),
-    )
-
-    if (!q) {
-      throw new AppError('Parámetro "q" es requerido', 400, 'QUERY_PARAM_REQUIRED')
-    }
-
-    const clientes = await clienteService.buscar(q, page, pageSize)
-    return sendSuccess(res, clientes)
   })
 
   update = catchAsync(async (req: Request, res: Response) => {

--- a/src/models/Cliente/cliente.controller.ts
+++ b/src/models/Cliente/cliente.controller.ts
@@ -3,7 +3,6 @@ import { ClienteService } from './cliente.service.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
 import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
 import { parsePagination } from '../../shared/utils/parsePagination.js'
-import { AppError } from '../../shared/errors/AppError.js'
 
 const clienteService = new ClienteService()
 

--- a/src/models/Cliente/cliente.repository.ts
+++ b/src/models/Cliente/cliente.repository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, cliente, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
+import type { PaginationParams } from '../../shared/types/pagination.js'
 
 export interface ClienteDeleteDependencyCounts {
   obras: number
@@ -20,32 +21,41 @@ export class ClienteRepository {
     })
   }
 
-  async findAll(): Promise<cliente[]> {
-    return await this.prisma.cliente.findMany({
-      orderBy: { razon_social: 'asc' },
-    })
-  }
-
   async findById(cuil: string): Promise<cliente | null> {
     return await this.prisma.cliente.findUnique({
       where: { cuil: cuil },
     })
   }
 
-  async buscar(q: string, limit?: number, offset?: number): Promise<cliente[]> {
-    return await this.prisma.cliente.findMany({
-      where: {
-        OR: [
-          { razon_social: { contains: q, mode: 'insensitive' } },
-          { cuil: { contains: q, mode: 'insensitive' } },
-          { nombre: { contains: q, mode: 'insensitive' } },
-          { apellido: { contains: q, mode: 'insensitive' } },
-        ],
-      },
-      take: limit,
-      skip: offset,
-      orderBy: { razon_social: 'asc' },
-    })
+  async findAll(
+    search?: string,
+    paginationConfig?: PaginationParams
+  ): Promise<{ data: cliente[]; total: number }> {
+    const whereClause: Prisma.clienteWhereInput = search ? {
+      OR: [
+        { razon_social: { contains: search, mode: 'insensitive' } },
+        { cuil: { contains: search, mode: 'insensitive' } },
+        { nombre: { contains: search, mode: 'insensitive' } },
+        { apellido: { contains: search, mode: 'insensitive' } },
+      ],
+    } : {}
+
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.cliente.findMany({
+        where: whereClause,
+        orderBy: { razon_social: 'asc' },
+        skip,
+        take,
+      }),
+      this.prisma.cliente.count({ where: whereClause })
+    ])
+
+    return { data, total }
   }
 
   async update(

--- a/src/models/Cliente/cliente.routes.spec.ts
+++ b/src/models/Cliente/cliente.routes.spec.ts
@@ -51,7 +51,7 @@ describe('Integration Tests - Cliente Routes', () => {
         .set('Authorization', `Bearer ${token}`)
 
       expect(response.status).toBe(200)
-      expect(response.body.data).toHaveLength(2)
+      expect(response.body.data.data).toHaveLength(2)
     })
   })
 

--- a/src/models/Cliente/cliente.routes.spec.ts
+++ b/src/models/Cliente/cliente.routes.spec.ts
@@ -38,10 +38,13 @@ describe('Integration Tests - Cliente Routes', () => {
     })
 
     it('debería devolver 200 y lista de clientes con token válido', async () => {
-      vi.spyOn(ClienteRepository.prototype, 'findAll').mockResolvedValue([
-        { cuil: '20111111112', razon_social: 'Empresa A' } as unknown as cliente,
-        { cuil: '20222222223', razon_social: 'Empresa B' } as unknown as cliente,
-      ])
+      vi.spyOn(ClienteRepository.prototype, 'findAll').mockResolvedValue({
+        data: [
+          { cuil: '20111111112', razon_social: 'Empresa A' } as unknown as cliente,
+          { cuil: '20222222223', razon_social: 'Empresa B' } as unknown as cliente,
+        ],
+        total: 2,
+      })
 
       const response = await request(app)
         .get('/api/clientes')

--- a/src/models/Cliente/cliente.routes.ts
+++ b/src/models/Cliente/cliente.routes.ts
@@ -13,12 +13,7 @@ const clienteRouter = Router()
  */
 clienteRouter.get('/', clienteController.getAll)
 
-/**
- * @route   GET /api/clientes/buscar
- * @desc    Buscar clientes con filtros
- * @access  Privado (requiere autenticación)
- */
-clienteRouter.get('/buscar', clienteController.buscar)
+
 
 /**
  * @route   POST /api/clientes

--- a/src/models/Cliente/cliente.service.ts
+++ b/src/models/Cliente/cliente.service.ts
@@ -1,6 +1,7 @@
 import { Prisma, cliente } from '@prisma/client'
 import { ClienteRepository } from './cliente.repository.js'
 import { AppError } from '../../shared/errors/AppError.js'
+import type { PaginationParams, PaginatedResponse } from '../../shared/types/pagination.js'
 
 export interface ClienteDependencyDetails {
   obras: number
@@ -26,8 +27,25 @@ export class ClienteService {
     return await this.repository.create(data)
   }
 
-  async findAll(): Promise<cliente[]> {
-    return await this.repository.findAll()
+  async findAll(
+    search?: string,
+    pagination?: PaginationParams
+  ): Promise<PaginatedResponse<cliente>> {
+    const { data, total } = await this.repository.findAll(search, pagination)
+
+    if (!pagination) {
+       return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+
+    return {
+      data,
+      total,
+      totalPages,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   async findById(cuil: string): Promise<cliente> {
@@ -36,12 +54,6 @@ export class ClienteService {
       throw new AppError('Cliente no encontrado', 404, 'CLIENTE_NOT_FOUND')
     }
     return cliente
-  }
-
-  async buscar(q: string, page = 1, pageSize = 25): Promise<cliente[]> {
-    const limit = Math.max(1, Math.min(100, pageSize))
-    const offset = (Math.max(1, page) - 1) * limit
-    return await this.repository.buscar(q, limit, offset)
   }
 
   async update(

--- a/src/models/Entrega/entrega.controller.ts
+++ b/src/models/Entrega/entrega.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express'
 import { EntregaService } from './entrega.service.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
-import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
+import { parsePagination } from '../../shared/utils/parsePagination.js'
 import { AppError } from '../../shared/errors/AppError.js'
 
 const entregaService = new EntregaService()
@@ -18,8 +19,10 @@ export class EntregaController {
   getAll = catchAsync(async (req: Request, res: Response) => {
     const search = req.query.q as string | undefined
     const estado = req.query.estado as string | undefined
-    const entregas = await entregaService.findAll(search, estado)
-    return sendSuccess(res, entregas)
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    
+    const result = await entregaService.findAll(search, estado, pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   getOne = catchAsync(async (req: Request, res: Response) => {
@@ -52,13 +55,15 @@ export class EntregaController {
   getEntregasByEmpleadoEstado = catchAsync(async (req: Request, res: Response) => {
     const { cuil_empleado, estado } = req.params
     const { search, date } = req.query as { search?: string; date?: string }
-    const entregas = await entregaService.getByEmpleadoEstado(
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await entregaService.getByEmpleadoEstado(
       cuil_empleado,
       estado,
       search,
       date,
+      pagination
     )
-    return sendSuccess(res, entregas)
+    return sendPaginatedSuccess(res, result)
   })
 
   finalizarEntrega = catchAsync(async (req: Request, res: Response) => {

--- a/src/models/Entrega/entrega.repository.ts
+++ b/src/models/Entrega/entrega.repository.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, entrega, Prisma } from '@prisma/client'
 
 import { prisma } from '../../shared/db/prismaClient.js'
+import type { PaginationParams } from '../../shared/types/pagination.js'
 
 const defaultInclude = {
   obra: {
@@ -57,7 +58,11 @@ export class EntregaRepository {
     return this.prisma.entrega.create({ data, include: defaultInclude })
   }
 
-  async findAll(search?: string, estado?: string): Promise<EntregaWithRelations[]> {
+  async findAll(
+    search?: string,
+    estado?: string,
+    paginationConfig?: PaginationParams
+  ): Promise<{ data: EntregaWithRelations[]; total: number }> {
     const whereClause: Prisma.entregaWhereInput = {}
 
     if (estado) {
@@ -87,11 +92,23 @@ export class EntregaRepository {
       ]
     }
 
-    return this.prisma.entrega.findMany({
-      where: whereClause,
-      orderBy: { fecha_hora_entrega: 'desc' },
-      include: defaultInclude,
-    })
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.entrega.findMany({
+        where: whereClause,
+        orderBy: { fecha_hora_entrega: 'desc' },
+        include: defaultInclude,
+        skip,
+        take,
+      }),
+      this.prisma.entrega.count({ where: whereClause })
+    ])
+
+    return { data: data as EntregaWithRelations[], total }
   }
 
   async getByEmpleadoEstado(
@@ -99,7 +116,8 @@ export class EntregaRepository {
     estado: string,
     search?: string,
     date?: string,
-  ): Promise<EntregaWithRelations[]> {
+    paginationConfig?: PaginationParams,
+  ): Promise<{ data: EntregaWithRelations[]; total: number }> {
     const whereClause: Prisma.entregaWhereInput = {
       estado: estado,
       entrega_empleado: {
@@ -142,11 +160,23 @@ export class EntregaRepository {
       ]
     }
 
-    return this.prisma.entrega.findMany({
-      where: whereClause,
-      include: defaultInclude,
-      orderBy: { fecha_hora_entrega: 'desc' },
-    })
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.entrega.findMany({
+        where: whereClause,
+        include: defaultInclude,
+        orderBy: { fecha_hora_entrega: 'desc' },
+        skip,
+        take,
+      }),
+      this.prisma.entrega.count({ where: whereClause }),
+    ])
+
+    return { data: data as EntregaWithRelations[], total }
   }
 
   async findById(cod_entrega: number): Promise<EntregaWithRelations | null> {

--- a/src/models/Entrega/entrega.service.ts
+++ b/src/models/Entrega/entrega.service.ts
@@ -6,6 +6,7 @@ import { VehiculoService } from '../Vehiculo/vehiculo.service.js'
 import { EmpleadoService } from '../Empleado/empleado.service.js'
 import { ValidationError } from '../../shared/errors/validationError.js'
 import { AppError } from '../../shared/errors/AppError.js'
+import type { PaginationParams, PaginatedResponse } from '../../shared/types/pagination.js'
 
 /**
  * Servicio para manejar la lógica de negocio de entregas.
@@ -136,8 +137,26 @@ export class EntregaService {
     return this.entregaRepository.create(payload)
   }
 
-  async findAll(search?: string, estado?: string): Promise<EntregaWithRelations[]> {
-    return this.entregaRepository.findAll(search, estado)
+  async findAll(
+    search?: string, 
+    estado?: string, 
+    pagination?: PaginationParams
+  ): Promise<PaginatedResponse<EntregaWithRelations>> {
+    const { data, total } = await this.entregaRepository.findAll(search, estado, pagination)
+
+    if (!pagination) {
+       return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+
+    return {
+      data,
+      total,
+      totalPages,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   async findById(cod_entrega: number): Promise<EntregaWithRelations> {
@@ -292,8 +311,34 @@ export class EntregaService {
     return this.entregaRepository.delete(cod_entrega)
   }
 
-  async getByEmpleadoEstado(cuilEmpleado: string, estado: string, search?: string, date?: string): Promise<entrega[]> {
-    return this.entregaRepository.getByEmpleadoEstado(cuilEmpleado, estado, search, date)
+  async getByEmpleadoEstado(
+    cuilEmpleado: string,
+    estado: string,
+    search?: string,
+    date?: string,
+    pagination?: PaginationParams
+  ): Promise<PaginatedResponse<EntregaWithRelations>> {
+    const { data, total } = await this.entregaRepository.getByEmpleadoEstado(
+      cuilEmpleado,
+      estado,
+      search,
+      date,
+      pagination
+    )
+
+    if (!pagination) {
+      return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+
+    return {
+      data,
+      total,
+      totalPages,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   async agregarOrdenesDeProduccion(cod_entrega: number, cod_ops: number[]): Promise<entrega> {

--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -2,7 +2,8 @@ import { ObraService } from './obra.service.js'
 import { Request, Response } from 'express'
 import type { NotasFabricaFilters } from './obra.repository.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
-import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
+import { parsePagination } from '../../shared/utils/parsePagination.js'
 import { AppError } from '../../shared/errors/AppError.js'
 
 const obraService = new ObraService()
@@ -24,11 +25,12 @@ export class ObraController {
    */
   filtrar = catchAsync(async (req: Request, res: Response) => {
     const { estado, localidad } = req.query
-    const obras = await obraService.filtrar({
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await obraService.filtrar({
       estado: estado as string | undefined,
       cod_localidad: localidad ? Number(localidad) : undefined,
-    })
-    return sendSuccess(res, obras)
+    }, pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**
@@ -36,8 +38,9 @@ export class ObraController {
    */
   buscar = catchAsync(async (req: Request, res: Response) => {
     const q = req.query.q as string
-    const obras = await obraService.buscar(q)
-    return sendSuccess(res, obras)
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await obraService.buscar(q, pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**
@@ -65,8 +68,9 @@ export class ObraController {
    * Gets all obras.
    */
   getAll = catchAsync(async (req: Request, res: Response) => {
-    const obras = await obraService.findAll()
-    return sendSuccess(res, obras)
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await obraService.findAll(pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, obra, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
+import type { PaginationParams } from '../../shared/types/pagination.js'
 
 export type NotasFabricaEstado =
   | 'SIN_ORDEN'
@@ -24,32 +25,54 @@ export class ObraRepository {
 
   // ----------- FILTROS Y BÚSQUEDAS -----------
 
-  async findAll() {
-    return await this.prisma.obra.findMany({
-      orderBy: { cod_obra: 'desc' },
-      include: {
-        cliente: true,
-        arquitecto: true,
-        localidad: {
-          include: {
-            provincia: true,
+  async findAll(pagination: PaginationParams): Promise<{ data: obra[]; total: number }> {
+    const skip = (pagination.page - 1) * pagination.pageSize
+    const take = pagination.pageSize
+
+    const [data, total] = await Promise.all([
+      this.prisma.obra.findMany({
+        orderBy: { cod_obra: 'desc' },
+        include: {
+          cliente: true,
+          arquitecto: true,
+          localidad: {
+            include: {
+              provincia: true,
+            },
           },
+          presupuesto: true,
+          pago: true,
         },
-        presupuesto: true,
-        pago: true,
-      },
-    })
+        skip,
+        take,
+      }),
+      this.prisma.obra.count(),
+    ])
+
+    return { data, total }
   }
   /** Filtra obras por estado, localidad o ambos */
-  async filtrar({
-    estado,
-    cod_localidad,
-  }: {
-    estado?: string
-    cod_localidad?: number
-  }) {
-    if (!estado && !cod_localidad) {
-      return this.prisma.obra.findMany({
+  async filtrar(
+    {
+      estado,
+      cod_localidad,
+    }: {
+      estado?: string
+      cod_localidad?: number
+    },
+    pagination: PaginationParams,
+  ): Promise<{ data: obra[]; total: number }> {
+    const skip = (pagination.page - 1) * pagination.pageSize
+    const take = pagination.pageSize
+
+    const where: Prisma.obraWhereInput = {
+      ...(estado && { estado }),
+      ...(cod_localidad && { cod_localidad }),
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.obra.findMany({
+        where,
         include: {
           cliente: true,
           arquitecto: true,
@@ -60,49 +83,49 @@ export class ObraRepository {
           },
         },
         orderBy: { fecha_ini: 'desc' },
-      })
-    }
-    return this.prisma.obra.findMany({
-      where: {
-        ...(estado && { estado }),
-        ...(cod_localidad && { cod_localidad }),
-      },
-      include: {
-        cliente: true,
-        arquitecto: true,
-        localidad: {
-          include: {
-            provincia: true,
-          },
-        },
-      },
-      orderBy: { fecha_ini: 'desc' },
-    })
+        skip,
+        take,
+      }),
+      this.prisma.obra.count({ where }),
+    ])
+
+    return { data, total }
   }
 
   /** Busca obras por texto (dirección, cliente, etc.) */
-  async buscar(q: string) {
-    return this.prisma.obra.findMany({
-      where: {
-        OR: [
-          { direccion: { contains: q, mode: 'insensitive' } },
-          { cliente: { razon_social: { contains: q, mode: 'insensitive' } } },
-          { cliente: { nombre: { contains: q, mode: 'insensitive' } } },
-          { cliente: { apellido: { contains: q, mode: 'insensitive' } } },
-        ],
-      },
-      include: {
-        cliente: true,
-        arquitecto: true,
-        localidad: {
-          include: {
-            provincia: true,
+  async buscar(q: string, pagination: PaginationParams): Promise<{ data: obra[]; total: number }> {
+    const skip = (pagination.page - 1) * pagination.pageSize
+    const take = pagination.pageSize
+
+    const where: Prisma.obraWhereInput = {
+      OR: [
+        { direccion: { contains: q, mode: 'insensitive' } },
+        { cliente: { razon_social: { contains: q, mode: 'insensitive' } } },
+        { cliente: { nombre: { contains: q, mode: 'insensitive' } } },
+        { cliente: { apellido: { contains: q, mode: 'insensitive' } } },
+      ],
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.obra.findMany({
+        where,
+        include: {
+          cliente: true,
+          arquitecto: true,
+          localidad: {
+            include: {
+              provincia: true,
+            },
           },
         },
-      },
-      orderBy: { cod_obra: 'desc' },
-      take: 10,
-    })
+        orderBy: { cod_obra: 'desc' },
+        skip,
+        take,
+      }),
+      this.prisma.obra.count({ where }),
+    ])
+
+    return { data, total }
   }
 
   /** Obtiene obras de un cliente específico */

--- a/src/models/Obra/obra.routes.spec.ts
+++ b/src/models/Obra/obra.routes.spec.ts
@@ -34,18 +34,39 @@ describe('Integration Tests - Obra Routes', () => {
       expect(response.status).toBe(401)
     })
 
-    it('debería devolver 200 y lista de obras', async () => {
-      vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue([
-        { cod_obra: 1, direccion: 'Calle Falsa 123', estado: 'ACTIVA' },
-        { cod_obra: 2, direccion: 'Av. Siempre Viva', estado: 'EN PRODUCCION' },
-      ] as unknown as Awaited<ReturnType<ObraRepository['findAll']>>)
+    it('debería devolver 200 y respuesta paginada con lista de obras', async () => {
+      vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue({
+        data: [
+          { cod_obra: 1, direccion: 'Calle Falsa 123', estado: 'ACTIVA' },
+          { cod_obra: 2, direccion: 'Av. Siempre Viva', estado: 'EN PRODUCCION' },
+        ] as unknown as Awaited<ReturnType<ObraRepository['findAll']>>['data'],
+        total: 2,
+      })
 
       const response = await request(app)
         .get('/api/obras')
         .set('Authorization', `Bearer ${token}`)
 
       expect(response.status).toBe(200)
-      expect(response.body.data).toHaveLength(2)
+      expect(response.body.data).toHaveProperty('data')
+      expect(response.body.data).toHaveProperty('total', 2)
+      expect(response.body.data).toHaveProperty('totalPages')
+      expect(response.body.data).toHaveProperty('page')
+      expect(response.body.data).toHaveProperty('pageSize')
+      expect(response.body.data.data).toHaveLength(2)
+    })
+
+    it('debería respetar los parámetros de paginación', async () => {
+      const findAllMock = vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue({
+        data: [],
+        total: 0,
+      })
+
+      await request(app)
+        .get('/api/obras?page=2&pageSize=10')
+        .set('Authorization', `Bearer ${token}`)
+
+      expect(findAllMock).toHaveBeenCalledWith({ page: 2, pageSize: 10 })
     })
   })
 

--- a/src/models/Obra/obra.service.spec.ts
+++ b/src/models/Obra/obra.service.spec.ts
@@ -95,4 +95,52 @@ describe('ObraService - Pruebas Unitarias', () => {
       )
     })
   })
+
+  describe('findAll() - Paginación', () => {
+    it('debería retornar PaginatedResponse con metadata correcta', async () => {
+      vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue({
+        data: [
+          { cod_obra: 1, direccion: 'Calle 1', estado: 'ACTIVA' },
+          { cod_obra: 2, direccion: 'Calle 2', estado: 'EN PRODUCCION' },
+        ] as unknown as Awaited<ReturnType<ObraRepository['findAll']>>['data'],
+        total: 50,
+      })
+
+      const result = await obraService.findAll({ page: 1, pageSize: 25 })
+
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({ cod_obra: 1 }),
+          expect.objectContaining({ cod_obra: 2 }),
+        ]),
+        total: 50,
+        totalPages: 2,
+        page: 1,
+        pageSize: 25,
+      })
+    })
+
+    it('debería calcular totalPages correctamente con valores no exactos', async () => {
+      vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue({
+        data: [],
+        total: 51,
+      })
+
+      const result = await obraService.findAll({ page: 1, pageSize: 25 })
+
+      expect(result.totalPages).toBe(3) // ceil(51/25) = 3
+      expect(result.total).toBe(51)
+    })
+
+    it('debería pasar los parámetros de paginación al repositorio', async () => {
+      const findAllMock = vi.spyOn(ObraRepository.prototype, 'findAll').mockResolvedValue({
+        data: [],
+        total: 0,
+      })
+
+      await obraService.findAll({ page: 3, pageSize: 10 })
+
+      expect(findAllMock).toHaveBeenCalledWith({ page: 3, pageSize: 10 })
+    })
+  })
 })

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -5,6 +5,7 @@ import {
 } from './obra.repository.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { ValidationError } from '../../shared/errors/validationError.js'
+import type { PaginationParams, PaginatedResponse } from '../../shared/types/pagination.js'
 
 type ObraCreateInputExtended = Prisma.obraCreateInput & {
   cuil?: string
@@ -40,16 +41,33 @@ export class ObraService {
   /**
    * Filters obras by status, location, or both.
    */
-  async filtrar(filtros: { estado?: string; cod_localidad?: number }): Promise<obra[]> {
-    return this.repository.filtrar(filtros)
+  async filtrar(
+    filtros: { estado?: string; cod_localidad?: number },
+    pagination: PaginationParams,
+  ): Promise<PaginatedResponse<obra>> {
+    const { data, total } = await this.repository.filtrar(filtros, pagination)
+    return {
+      data,
+      total,
+      totalPages: Math.ceil(total / pagination.pageSize),
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   /**
    * Searches obras by text (address, client, etc.).
    */
-  async buscar(q: string): Promise<obra[]> {
-    if (!q) return this.findAll()
-    return this.repository.buscar(q)
+  async buscar(q: string, pagination: PaginationParams): Promise<PaginatedResponse<obra>> {
+    if (!q) return this.findAll(pagination)
+    const { data, total } = await this.repository.buscar(q, pagination)
+    return {
+      data,
+      total,
+      totalPages: Math.ceil(total / pagination.pageSize),
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   /**
@@ -60,10 +78,17 @@ export class ObraService {
   }
 
   /**
-   * Gets all obras.
+   * Gets all obras (paginated).
    */
-  async findAll(): Promise<obra[]> {
-    return this.repository.findAll()
+  async findAll(pagination: PaginationParams): Promise<PaginatedResponse<obra>> {
+    const { data, total } = await this.repository.findAll(pagination)
+    return {
+      data,
+      total,
+      totalPages: Math.ceil(total / pagination.pageSize),
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   /**

--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express'
 import { visitaService } from './visita.service.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
-import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
+import { parsePagination } from '../../shared/utils/parsePagination.js'
 import { AppError } from '../../shared/errors/AppError.js'
 
 /**
@@ -21,8 +22,9 @@ export class VisitaController {
    */
   getAll = catchAsync(async (req: Request, res: Response) => {
     const estado = req.query.estado as string | undefined
-    const visitas = await visitaService.findAll(estado)
-    return sendSuccess(res, visitas)
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await visitaService.findAll(estado, pagination)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**
@@ -39,19 +41,15 @@ export class VisitaController {
    */
   buscar = catchAsync(async (req: Request, res: Response) => {
     const q = String(req.query.q ?? '').trim()
-    const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10))
-    const pageSize = Math.max(
-      1,
-      Math.min(100, parseInt(String(req.query.pageSize ?? '25'), 10)),
-    )
+    const pagination = parsePagination(req.query as Record<string, unknown>)
 
     if (!q) {
       throw new AppError('El parámetro de búsqueda "q" es requerido', 400, 'MISSING_PARAMS')
     }
 
     const estado = req.query.estado as string | undefined
-    const visitas = await visitaService.buscar(q, page, pageSize, estado)
-    return sendSuccess(res, visitas)
+    const result = await visitaService.buscar(q, pagination, estado)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**
@@ -78,11 +76,15 @@ export class VisitaController {
   getVisitasByEmpleadoAndEstado = catchAsync(async (req: Request, res: Response) => {
     const cuil = req.params.cuil
     const estado = req.params.estado
+    const pagination = parsePagination(req.query as Record<string, unknown>)
     const visitas = await visitaService.getVisitasByEmpleadoAndEstado(
       cuil,
       estado,
+      undefined,
+      undefined,
+      pagination
     )
-    return sendSuccess(res, visitas)
+    return sendPaginatedSuccess(res, visitas)
   })
 
   /**
@@ -99,14 +101,15 @@ export class VisitaController {
         ? estado
         : [estado]
       : undefined
-
+    const pagination = parsePagination(req.query as Record<string, unknown>)
     const visitas = await visitaService.getVisitasByEmpleado(
       cuil,
       estadosArray,
       search,
       date,
+      pagination
     )
-    return sendSuccess(res, visitas)
+    return sendPaginatedSuccess(res, visitas)
   })
 
   /**

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, visita, Prisma } from '@prisma/client'
 import { prisma } from '../../shared/db/prismaClient.js'
+import type { PaginationParams } from '../../shared/types/pagination.js'
 
 export type VisitaWithRelations = Prisma.visitaGetPayload<{
   include: {
@@ -30,15 +31,20 @@ export class VisitaRepository {
   }
 
   // Obtener todas las visitas
-  async findAll(estado?: string): Promise<VisitaWithRelations[]> {
+  async findAll(
+    estado?: string,
+    paginationConfig?: PaginationParams
+  ): Promise<{ data: VisitaWithRelations[]; total: number }> {
     const whereClause: Prisma.visitaWhereInput = estado
       ? { estado: { equals: estado, mode: 'insensitive' } }
       : {}
 
-    return await this.prisma.visita.findMany({
-      where: whereClause,
-      orderBy: { fecha_hora_visita: 'desc' },
-      include: {
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const includeOptions = {
         obra: {
           include: {
             cliente: true,
@@ -56,8 +62,20 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
-      },
-    }) as VisitaWithRelations[]
+      }
+
+    const [data, total] = await Promise.all([
+      this.prisma.visita.findMany({
+        where: whereClause,
+        orderBy: { fecha_hora_visita: 'desc' },
+        include: includeOptions,
+        take,
+        skip,
+      }),
+      this.prisma.visita.count({ where: whereClause }),
+    ])
+
+    return { data: data as VisitaWithRelations[], total }
   }
 
   // Obtener visita por cod_visita
@@ -211,10 +229,9 @@ export class VisitaRepository {
 
   async buscar(
     q: string,
-    limit?: number,
-    offset?: number,
+    paginationConfig?: PaginationParams,
     estado?: string,
-  ): Promise<VisitaWithRelations[]> {
+  ): Promise<{ data: VisitaWithRelations[]; total: number }> {
     const filters: Prisma.visitaWhereInput[] = [
       {
         OR: [
@@ -245,9 +262,12 @@ export class VisitaRepository {
       filters.push({ estado: { equals: estado, mode: 'insensitive' } })
     }
 
-    return await this.prisma.visita.findMany({
-      where: { AND: filters },
-      include: {
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const includeOptions = {
         obra: {
           include: {
             cliente: true,
@@ -265,11 +285,20 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
-      },
-      take: limit,
-      skip: offset,
-      orderBy: { fecha_hora_visita: 'desc' },
-    }) as VisitaWithRelations[]
+      }
+
+    const [data, total] = await Promise.all([
+      this.prisma.visita.findMany({
+        where: { AND: filters },
+        include: includeOptions,
+        take,
+        skip,
+        orderBy: { fecha_hora_visita: 'desc' },
+      }),
+      this.prisma.visita.count({ where: { AND: filters } })
+    ])
+
+    return { data: data as VisitaWithRelations[], total }
   }
 
   async findByEmpleadoAndEstado(
@@ -277,7 +306,8 @@ export class VisitaRepository {
     estado: string | string[],
     search?: string,
     date?: string,
-  ): Promise<VisitaWithRelations[]> {
+    paginationConfig?: PaginationParams,
+  ): Promise<{ data: VisitaWithRelations[]; total: number }> {
     const whereClause: Prisma.visitaWhereInput = {
       estado: Array.isArray(estado) ? { in: estado } : estado,
       empleado_visita: {
@@ -322,31 +352,43 @@ export class VisitaRepository {
       ]
     }
 
-    return await this.prisma.visita.findMany({
-      where: whereClause,
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.visita.findMany({
+        where: whereClause,
+        include: {
+          obra: {
+            include: {
+              cliente: true,
+              localidad: true,
+            },
+          },
+          localidad: true,
+          empleado_visita: {
+            include: {
+              empleado: true,
+            },
+          },
+          uso_vehiculo_visita: {
+            include: {
+              vehiculo: true,
+            },
           },
         },
-        localidad: true,
-        empleado_visita: {
-          include: {
-            empleado: true,
-          },
+        orderBy: {
+          fecha_hora_visita: 'desc',
         },
-        uso_vehiculo_visita: {
-          include: {
-            vehiculo: true,
-          },
-        },
-      },
-      orderBy: {
-        fecha_hora_visita: 'desc',
-      },
-    }) as VisitaWithRelations[]
+        skip,
+        take,
+      }),
+      this.prisma.visita.count({ where: whereClause })
+    ])
+
+    return { data: data as VisitaWithRelations[], total }
   }
 
   // Obtener todas las visitas de un empleado
@@ -355,7 +397,8 @@ export class VisitaRepository {
     estados?: string[],
     search?: string,
     date?: string,
-  ): Promise<VisitaWithRelations[]> {
+    paginationConfig?: PaginationParams,
+  ): Promise<{ data: VisitaWithRelations[]; total: number }> {
     const whereClause: Prisma.visitaWhereInput = {
       empleado_visita: {
         some: {
@@ -402,31 +445,43 @@ export class VisitaRepository {
       ]
     }
 
-    return await this.prisma.visita.findMany({
-      where: whereClause,
-      include: {
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
+    const skip = paginationConfig
+      ? (paginationConfig.page - 1) * paginationConfig.pageSize
+      : undefined
+    const take = paginationConfig ? paginationConfig.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.visita.findMany({
+        where: whereClause,
+        include: {
+          obra: {
+            include: {
+              cliente: true,
+              localidad: true,
+            },
+          },
+          empleado_visita: {
+            include: {
+              empleado: true,
+            },
+          },
+          localidad: true,
+          uso_vehiculo_visita: {
+            include: {
+              vehiculo: true,
+            },
           },
         },
-        empleado_visita: {
-          include: {
-            empleado: true,
-          },
+        orderBy: {
+          fecha_hora_visita: 'desc',
         },
-        localidad: true,
-        uso_vehiculo_visita: {
-          include: {
-            vehiculo: true,
-          },
-        },
-      },
-      orderBy: {
-        fecha_hora_visita: 'desc',
-      },
-    }) as VisitaWithRelations[]
+        skip,
+        take,
+      }),
+      this.prisma.visita.count({ where: whereClause })
+    ])
+
+    return { data: data as VisitaWithRelations[], total }
   }
 }
 

--- a/src/models/Visita/visita.routes.spec.ts
+++ b/src/models/Visita/visita.routes.spec.ts
@@ -55,7 +55,7 @@ describe('Integration Tests - Visita Routes', () => {
         .set('Authorization', `Bearer ${token}`)
 
       expect(response.status).toBe(200)
-      expect(response.body.data).toHaveLength(2)
+      expect(response.body.data.data).toHaveLength(2)
     })
   })
 

--- a/src/models/Visita/visita.routes.spec.ts
+++ b/src/models/Visita/visita.routes.spec.ts
@@ -42,10 +42,13 @@ describe('Integration Tests - Visita Routes', () => {
     })
 
     it('debería devolver 200 y la lista de visitas', async () => {
-      vi.spyOn(VisitaRepository.prototype, 'findAll').mockResolvedValue([
-        { cod_visita: 1, motivo_visita: 'Presupuesto', estado: 'PROGRAMADA' } as unknown as VisitaWithRelations,
-        { cod_visita: 2, motivo_visita: 'Medición', estado: 'COMPLETADA' } as unknown as VisitaWithRelations,
-      ])
+      vi.spyOn(VisitaRepository.prototype, 'findAll').mockResolvedValue({
+        data: [
+          { cod_visita: 1, motivo_visita: 'Presupuesto', estado: 'PROGRAMADA' } as unknown as VisitaWithRelations,
+          { cod_visita: 2, motivo_visita: 'Medición', estado: 'COMPLETADA' } as unknown as VisitaWithRelations,
+        ],
+        total: 2,
+      })
 
       const response = await request(app)
         .get('/api/visitas')

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -6,6 +6,7 @@ import { ValidationError } from '../../shared/errors/validationError.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { emailService } from '../../shared/providers/email/index.js'
 import { notificationConfigRepository } from '../../shared/providers/email/NotificationConfigRepository.js'
+import type { PaginationParams, PaginatedResponse } from '../../shared/types/pagination.js'
 
 /**
  * Interface for creating a new Visita.
@@ -164,10 +165,27 @@ export class VisitaService {
   }
 
   /**
-   * Gets all visits, optionally filtered by status.
+   * Gets all visits, optionally filtered by status, with pagination
    */
-  async findAll(estado?: string): Promise<VisitaWithRelations[]> {
-    return await this.visitaRepository.findAll(estado)
+  async findAll(
+    estado?: string, 
+    pagination?: PaginationParams
+  ): Promise<PaginatedResponse<VisitaWithRelations>> {
+    const { data, total } = await this.visitaRepository.findAll(estado, pagination)
+    
+    if (!pagination) {
+       return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+
+    return {
+      data,
+      total,
+      totalPages,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   /**
@@ -186,16 +204,20 @@ export class VisitaService {
    */
   async buscar(
     q: string,
-    page = 1,
-    pageSize = 25,
+    pagination: PaginationParams,
     estado?: string,
-  ): Promise<VisitaWithRelations[]> {
-    return await this.visitaRepository.buscar(
-      q,
-      pageSize,
-      (Math.max(1, page) - 1) * Math.max(1, Math.min(100, pageSize)),
-      estado,
-    )
+  ): Promise<PaginatedResponse<VisitaWithRelations>> {
+    const { data, total } = await this.visitaRepository.buscar(q, pagination, estado)
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+
+    return {
+      data,
+      total,
+      totalPages,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+    }
   }
 
   /**
@@ -358,14 +380,23 @@ export class VisitaService {
     estado: string[] | string,
     search?: string,
     date?: string,
-  ): Promise<VisitaWithRelations[]> {
+    pagination?: PaginationParams,
+  ): Promise<PaginatedResponse<VisitaWithRelations>> {
     const estadosArray = Array.isArray(estado) ? estado : [estado]
-    return await this.visitaRepository.findByEmpleadoAndEstado(
+    const { data, total } = await this.visitaRepository.findByEmpleadoAndEstado(
       cuil,
       estadosArray,
       search,
       date,
+      pagination,
     )
+
+    if (!pagination) {
+      return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+    return { data, total, totalPages, page: pagination.page, pageSize: pagination.pageSize }
   }
 
   /**
@@ -376,13 +407,22 @@ export class VisitaService {
     estados?: string[],
     search?: string,
     date?: string,
-  ): Promise<VisitaWithRelations[]> {
-    return await this.visitaRepository.findByEmpleado(
+    pagination?: PaginationParams,
+  ): Promise<PaginatedResponse<VisitaWithRelations>> {
+    const { data, total } = await this.visitaRepository.findByEmpleado(
       cuil,
       estados,
       search,
       date,
+      pagination,
     )
+
+    if (!pagination) {
+       return { data, total, totalPages: 1, page: 1, pageSize: Math.max(total, 1) }
+    }
+
+    const totalPages = Math.ceil(total / pagination.pageSize) || 1
+    return { data, total, totalPages, page: pagination.page, pageSize: pagination.pageSize }
   }
 
   /**

--- a/src/shared/types/pagination.ts
+++ b/src/shared/types/pagination.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared pagination types and constants.
+ * These are designed to be reused across all modules.
+ */
+
+/** Query params received from the client */
+export interface PaginationParams {
+  page: number
+  pageSize: number
+}
+
+/** Standardized paginated response wrapper */
+export interface PaginatedResponse<T> {
+  data: T[]
+  total: number
+  totalPages: number
+  page: number
+  pageSize: number
+}
+
+/** Default pagination values */
+export const PAGINATION_DEFAULTS = {
+  page: 1,
+  pageSize: 25,
+  maxPageSize: 100,
+} as const

--- a/src/shared/utils/apiResponse.ts
+++ b/src/shared/utils/apiResponse.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express'
+import type { PaginatedResponse } from '../types/pagination.js'
 
 /**
  * Common success response format.
@@ -31,6 +32,22 @@ export const sendSuccess = <T>(
     status: 'success',
     message,
     data,
+  })
+}
+
+/**
+ * Standardized paginated success sender.
+ * Wraps PaginatedResponse inside the standard { status, data } envelope.
+ */
+export const sendPaginatedSuccess = <T>(
+  res: Response,
+  paginatedData: PaginatedResponse<T>,
+  message?: string,
+): Response<ApiResponse<PaginatedResponse<T>>> => {
+  return res.status(200).json({
+    status: 'success',
+    message,
+    data: paginatedData,
   })
 }
 

--- a/src/shared/utils/parsePagination.ts
+++ b/src/shared/utils/parsePagination.ts
@@ -1,0 +1,29 @@
+import {
+  PAGINATION_DEFAULTS,
+  type PaginationParams,
+} from '../types/pagination.js'
+
+/**
+ * Parses and validates pagination query parameters.
+ * Clamps pageSize to maxPageSize and ensures page >= 1.
+ */
+export function parsePagination(
+  query: Record<string, unknown>,
+): PaginationParams {
+  let page = Number(query.page)
+  let pageSize = Number(query.pageSize)
+
+  if (!Number.isFinite(page) || page < 1) {
+    page = PAGINATION_DEFAULTS.page
+  }
+
+  if (!Number.isFinite(pageSize) || pageSize < 1) {
+    pageSize = PAGINATION_DEFAULTS.pageSize
+  }
+
+  if (pageSize > PAGINATION_DEFAULTS.maxPageSize) {
+    pageSize = PAGINATION_DEFAULTS.maxPageSize
+  }
+
+  return { page: Math.floor(page), pageSize: Math.floor(pageSize) }
+}


### PR DESCRIPTION
### Issue Relacionada
Closes #129 

### Resumen
Este PR implementa el sistema de paginación con scroll infinito para los listados de visitas y entregas de empleados en los módulos de terreno (Visitador y Planta), mejorando la eficiencia en la carga de datos y la experiencia de usuario en dispositivos móviles.

### Cambios Técnicos Implementados

* Estandarización de Paginación: Se refactorizaron los repositorios y servicios de Visita y Entrega para soportar la interfaz común PaginationParams y retornar objetos PaginatedResponse.

* Refactorización de Controladores: Se actualizaron los endpoints getByEmpleadoEstado para utilizar utilidades de parsing de paginación (parsePagination) y respuestas estandarizadas (sendPaginatedSuccess).

* Optimización de Consultas: Se implementó el uso de skip y take en las consultas de base de datos para recuperar solo los fragmentos de datos necesarios.

### Guía para Pruebas y Revisión
* Verificar que los endpoints /api/visitas/empleado/:cuil y /api/entregas/:cuil/:estado devuelven ahora un objeto con estructura { data, total, totalPages, page, pageSize }.

* Iniciar la aplicación y navegar a /visitador o /planta.
Verificar que se cargan los primeros 10 registros (o el valor de PAGE_SIZE).

* Desplazarse al final de la lista lateral.
Verificar éxito: Ver el indicador de "Cargando más..." brevemente y notar cómo se anexan nuevos registros sin que la lista se reinicie ni se pierda la selección actual.

* Realizar una búsqueda o filtrar por fecha.
Verificar comportamiento: La lista debe reiniciarse a la página 1 y mostrar solo los resultados filtrados. Al hacer scroll de nuevo, debe continuar paginando sobre los resultados filtrados.