### PR TITLE
Fix: Incluir estados activos de producción en el cálculo de cuentas por cobrar

### DIFF
--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -79,7 +79,7 @@ export class ObraController {
   getOne = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     const obra = await obraService.findById(id)
     return sendSuccess(res, obra)
   })
@@ -215,7 +215,7 @@ export class ObraController {
   update = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     const obra = await obraService.update(id, req.body)
     return sendSuccess(res, obra, 'Obra updated successfully')
   })
@@ -226,7 +226,7 @@ export class ObraController {
   bajaLogica = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     const obra = await obraService.bajaLogica(id)
     return sendSuccess(res, obra, 'Obra cancelled successfully')
   })
@@ -237,7 +237,7 @@ export class ObraController {
   remove = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     await obraService.remove(id)
     return res.status(204).send()
   })
@@ -281,7 +281,7 @@ export class ObraController {
   solicitarStock = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     const obra = await obraService.solicitarStock(id)
     return sendSuccess(res, obra, 'Stock requested successfully')
   })
@@ -292,7 +292,7 @@ export class ObraController {
   recibirStock = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
-    
+
     const obra = await obraService.recibirStock(id)
     return sendSuccess(res, obra, 'Stock received and obra now in production')
   })

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -368,7 +368,15 @@ export class ObraService {
   async getCuentasPorCobrar(): Promise<number> {
     const obrasPendientes = await prisma.obra.findMany({
       where: {
-        estado: { in: ['PAGADA PARCIALMENTE', 'EN ESPERA DE PAGO'] },
+        estado: { 
+          in: [
+            'PAGADA PARCIALMENTE', 
+            'EN ESPERA DE PAGO',
+            'EN ESPERA DE STOCK',
+            'EN PRODUCCION',
+            'PRODUCCION FINALIZADA'
+          ] 
+        },
       },
       include: {
         presupuesto: {


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
-->
Este PR ajusta la lógica del cálculo financiero del módulo `Obra` para asegurar que el "Total a Deber" rastree las cuentas activas a lo largo de toda la cadena de producción, reparando el problema de falsos `$0` en los dashboards del sistema.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
-->
- **Cálculo de Deudas (`obra.service.ts`):** Se ha extendido la consulta en `getCuentasPorCobrar` para computar obras que continúan con saldo pendiente mientras avanzan en el flujo. Ahora incluye los estados: `EN ESPERA DE STOCK`, `EN PRODUCCION` y `PRODUCCION FINALIZADA`.
- **Limpieza del Controlador (`obra.controller.ts`):** Se resolvieron espacios en blanco innecesarios en la delegación de errores del controlador.

### Cómo Probar los Cambios
<!-- Describe los pasos para que un revisor pueda replicar y aprobar tu solución. -->
1. Ingresa a la aplicación (Asegúrate de no tener problemas de caché, espera ~30s si acabas de recompilar).
2. Ve a cualquier ficha de Obra que posea un **Presupuesto Aceptado**.
3. Cambia manualmente su estado a `EN PRODUCCION`, `PRODUCCION FINALIZADA` o `EN ESPERA DE STOCK`, y asegúrate de que sus pagos acreditados sean menores a su presupuesto (que tenga deuda pendiente).
4. Dirígete a la ruta `/ventas` o `/admin` y verifica que el panel dinámico de "Total Por Cobrar" refleje correctamente el incremento financiero ocasionado por esa obra que se encuentra en la fase de fábrica.
