### PR TITLE
Feat/stock request

### DIFF
--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -287,14 +287,14 @@ export class ObraController {
   })
 
   /**
-   * Changes obra status to EN PRODUCCION.
+   * Changes obra status to EN PRODUCCION manually.
    */
-  recibirStock = catchAsync(async (req: Request, res: Response) => {
+  iniciarProduccion = catchAsync(async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10)
     if (isNaN(id)) throw new AppError('ID de obra inválido', 400, 'INVALID_ID')
 
-    const obra = await obraService.recibirStock(id)
-    return sendSuccess(res, obra, 'Stock received and obra now in production')
+    const obra = await obraService.iniciarProduccion(id)
+    return sendSuccess(res, obra, 'Obra in production successfully')
   })
 
   // ----------- STATS -----------

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -416,15 +416,12 @@ export class ObraRepository {
   }
 
   /**
-   * Obtiene obras de empresas con estado 'PAGADA PARCIALMENTE'
+   * Obtiene obras con estado 'PAGADA PARCIALMENTE' para pedir stock
    */
   async findObrasParaPedidoStock(): Promise<obra[]> {
     return this.prisma.obra.findMany({
       where: {
         estado: 'PAGADA PARCIALMENTE',
-        cliente: {
-          tipo_cliente: 'EMPRESA',
-        },
       },
       include: {
         cliente: true,

--- a/src/models/Obra/obra.routes.ts
+++ b/src/models/Obra/obra.routes.ts
@@ -49,8 +49,9 @@ obraRouter.get('/con-presupuesto-aceptado', authorize('obra', 'verConPresupuesto
 // Solicitar stock para una obra
 obraRouter.patch('/:id/solicitar-stock', authorize('obra', 'solicitarStock'), obraController.solicitarStock)
 
-// Confirmar recepción de stock
-obraRouter.patch('/:id/recibir-stock', authorize('obra', 'recibirStock'), obraController.recibirStock)
+// Confirmar recepción de stock (Ahora lo maneja PedidoStock)
+// Iniciar producción manualmente
+obraRouter.patch('/:id/iniciar-produccion', authorize('obra', 'iniciarProduccion'), obraController.iniciarProduccion)
 
 // Finalizar producción de una obra
 obraRouter.patch('/:id/finalizar-produccion', authorize('obra', 'finalizarProduccion'), obraController.finalizarProduccion)

--- a/src/models/Obra/obra.service.spec.ts
+++ b/src/models/Obra/obra.service.spec.ts
@@ -42,19 +42,19 @@ describe('ObraService - Pruebas Unitarias', () => {
     })
   })
 
-  describe('recibirStock()', () => {
-    it('debería fallar si el estado no es EN ESPERA DE STOCK', async () => {
+  describe('iniciarProduccion()', () => {
+    it('debería fallar si el estado no es PAGADA PARCIALMENTE', async () => {
       vi.spyOn(ObraRepository.prototype, 'findById').mockResolvedValue({
         cod_obra: 1,
         estado: 'PENDIENTE',
       } as unknown as Awaited<ReturnType<ObraRepository['findById']>>)
-      await expect(obraService.recibirStock(1)).rejects.toThrow('Esta obra no está esperando stock.')
+      await expect(obraService.iniciarProduccion(1)).rejects.toThrow('Esta obra no está lista para iniciar producción (Debe estar pagada parcialmente y tener stock).')
     })
 
     it('debería cambiar a EN PRODUCCION exitosamente', async () => {
       vi.spyOn(ObraRepository.prototype, 'findById').mockResolvedValue({
         cod_obra: 2,
-        estado: 'EN ESPERA DE STOCK',
+        estado: 'PAGADA PARCIALMENTE',
       } as unknown as Awaited<ReturnType<ObraRepository['findById']>>)
 
       const updateMock = vi.spyOn(ObraRepository.prototype, 'update').mockResolvedValue({
@@ -62,7 +62,7 @@ describe('ObraService - Pruebas Unitarias', () => {
         estado: 'EN PRODUCCION',
       } as unknown as Awaited<ReturnType<ObraRepository['update']>>)
 
-      await obraService.recibirStock(2)
+      await obraService.iniciarProduccion(2)
       expect(updateMock).toHaveBeenCalledWith(2, { estado: 'EN PRODUCCION' })
     })
   })

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -377,12 +377,12 @@ export class ObraService {
   }
 
   /**
-   * Changes obra status to EN PRODUCCION.
+   * Changes obra status to EN PRODUCCION manually by Production worker.
    */
-  async recibirStock(id: number): Promise<obra> {
+  async iniciarProduccion(id: number): Promise<obra> {
     const obra = await this.findById(id)
-    if (obra.estado !== 'EN ESPERA DE STOCK') {
-      throw new ValidationError('Esta obra no está esperando stock.', 'INVALID_STATE')
+    if (obra.estado !== 'PAGADA PARCIALMENTE') {
+      throw new ValidationError('Esta obra no está lista para iniciar producción (Debe estar pagada parcialmente y tener stock).', 'INVALID_STATE')
     }
     const updated = await this.repository.update(id, { estado: 'EN PRODUCCION' })
     eventBus.emit('obra.cambio_estado', { cod_obra: id, nuevo_estado: updated.estado })

--- a/src/models/PedidoStock/pedidoStock.controller.ts
+++ b/src/models/PedidoStock/pedidoStock.controller.ts
@@ -1,0 +1,52 @@
+import { Request, Response } from 'express'
+import { PedidoStockService } from './pedidoStock.service.js'
+import { catchAsync } from '../../shared/utils/catchAsync.js'
+import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { AppError } from '../../shared/errors/AppError.js'
+import type { EstadoPedidoStock } from '@prisma/client'
+
+const pedidoStockService = new PedidoStockService()
+
+export class PedidoStockController {
+  create = catchAsync(async (req: Request, res: Response) => {
+    const { obraId, descripcion } = req.body
+    
+    if (!obraId || !descripcion) {
+      throw new AppError('Faltan campos requeridos (obraId, descripcion)', 400, 'BAD_REQUEST')
+    }
+
+    // Determine initial state based on user role
+    const rol = req.user?.rol_actual
+    const estadoInicial: EstadoPedidoStock = rol === 'COORDINACION' ? 'PEDIDO' : 'PENDIENTE'
+
+    const pedido = await pedidoStockService.create({
+      obraId: Number(obraId),
+      descripcion,
+      estadoInicial
+    })
+
+    return sendSuccess(res, pedido, 'Pedido de stock creado exitosamente', 201)
+  })
+
+  getAll = catchAsync(async (req: Request, res: Response) => {
+    const pedidos = await pedidoStockService.findAll()
+    return sendSuccess(res, pedidos)
+  })
+
+  updateEstado = catchAsync(async (req: Request, res: Response) => {
+    const { id } = req.params
+    const { estado } = req.body
+
+    if (!estado) {
+      throw new AppError('El campo estado es requerido', 400, 'BAD_REQUEST')
+    }
+
+    const validEstados: EstadoPedidoStock[] = ['PENDIENTE', 'APROBADO', 'PEDIDO', 'RECIBIDO']
+    if (!validEstados.includes(estado as EstadoPedidoStock)) {
+      throw new AppError('Estado inválido', 400, 'INVALID_STATE')
+    }
+
+    const pedido = await pedidoStockService.updateEstado(id, estado as EstadoPedidoStock)
+    return sendSuccess(res, pedido, 'Estado del pedido actualizado')
+  })
+}

--- a/src/models/PedidoStock/pedidoStock.repository.ts
+++ b/src/models/PedidoStock/pedidoStock.repository.ts
@@ -1,0 +1,67 @@
+import { prisma } from '../../shared/db/prismaClient.js'
+import type { Prisma, pedido_stock } from '@prisma/client'
+
+export class PedidoStockRepository {
+  async create(data: Prisma.pedido_stockCreateInput): Promise<pedido_stock> {
+    return prisma.pedido_stock.create({
+      data,
+      include: {
+        obra: {
+          include: {
+            localidad: true,
+            cliente: true,
+          },
+        },
+      },
+    })
+  }
+
+  async findAll(): Promise<pedido_stock[]> {
+    return prisma.pedido_stock.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: {
+        obra: {
+          include: {
+            localidad: true,
+            cliente: true,
+          },
+        },
+      },
+    })
+  }
+
+  async findById(id: string): Promise<pedido_stock | null> {
+    return prisma.pedido_stock.findUnique({
+      where: { id },
+      include: {
+        obra: {
+          include: {
+            localidad: true,
+            cliente: true,
+          },
+        },
+      },
+    })
+  }
+
+  async update(id: string, data: Prisma.pedido_stockUpdateInput): Promise<pedido_stock> {
+    return prisma.pedido_stock.update({
+      where: { id },
+      data,
+      include: {
+        obra: {
+          include: {
+            localidad: true,
+            cliente: true,
+          },
+        },
+      },
+    })
+  }
+
+  async delete(id: string): Promise<pedido_stock> {
+    return prisma.pedido_stock.delete({
+      where: { id },
+    })
+  }
+}

--- a/src/models/PedidoStock/pedidoStock.routes.ts
+++ b/src/models/PedidoStock/pedidoStock.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { PedidoStockController } from './pedidoStock.controller.js'
+import { authorize } from '../../shared/middlewares/authorizationRoles.js'
+
+const pedidoStockController = new PedidoStockController()
+const pedidoStockRouter = Router()
+
+pedidoStockRouter.get('/', authorize('pedidoStock', 'obtener'), pedidoStockController.getAll)
+pedidoStockRouter.post('/', authorize('pedidoStock', 'crear'), pedidoStockController.create)
+pedidoStockRouter.patch('/:id/estado', authorize('pedidoStock', 'actualizarEstado'), pedidoStockController.updateEstado)
+
+export default pedidoStockRouter

--- a/src/models/PedidoStock/pedidoStock.service.ts
+++ b/src/models/PedidoStock/pedidoStock.service.ts
@@ -1,0 +1,94 @@
+import { PedidoStockRepository } from './pedidoStock.repository.js'
+import { AppError } from '../../shared/errors/AppError.js'
+import { ValidationError } from '../../shared/errors/validationError.js'
+import { prisma } from '../../shared/db/prismaClient.js'
+import { eventBus } from '../../shared/events/eventBus.js'
+import type { pedido_stock, EstadoPedidoStock } from '@prisma/client'
+import crypto from 'crypto'
+
+export interface CreatePedidoStockDTO {
+  obraId: number
+  descripcion: string
+  estadoInicial: EstadoPedidoStock
+}
+
+export class PedidoStockService {
+  private repository: PedidoStockRepository
+
+  constructor() {
+    this.repository = new PedidoStockRepository()
+  }
+
+  async create(data: CreatePedidoStockDTO): Promise<pedido_stock> {
+    const obra = await prisma.obra.findUnique({ where: { cod_obra: data.obraId } })
+    
+    if (!obra) {
+      throw new AppError('La obra especificada no existe.', 404, 'OBRA_NOT_FOUND')
+    }
+
+    if (obra.estado !== 'PAGADA PARCIALMENTE') {
+      throw new ValidationError(
+        'Solo se puede solicitar stock para obras con pago parcial.',
+        'INVALID_STATE'
+      )
+    }
+
+    const existingPedido = await prisma.pedido_stock.findUnique({
+      where: { obraId: data.obraId }
+    })
+
+    if (existingPedido) {
+      throw new ValidationError(
+        'Esta obra ya tiene un pedido de stock asociado.',
+        'ALREADY_EXISTS'
+      )
+    }
+
+    const id = crypto.randomUUID()
+
+    const pedido = await this.repository.create({
+      id,
+      descripcion: data.descripcion,
+      estado: data.estadoInicial,
+      updatedAt: new Date(),
+      obra: {
+        connect: { cod_obra: data.obraId }
+      }
+    })
+
+    const updatedObra = await prisma.obra.update({
+      where: { cod_obra: data.obraId },
+      data: { estado: 'EN ESPERA DE STOCK' }
+    })
+
+    eventBus.emit('obra.cambio_estado', { cod_obra: data.obraId, nuevo_estado: updatedObra.estado })
+
+    return pedido
+  }
+
+  async findAll(): Promise<pedido_stock[]> {
+    return this.repository.findAll()
+  }
+
+  async updateEstado(id: string, nuevoEstado: EstadoPedidoStock): Promise<pedido_stock> {
+    const pedido = await this.repository.findById(id)
+    if (!pedido) {
+      throw new AppError('Pedido de stock no encontrado', 404, 'NOT_FOUND')
+    }
+
+    const updatedPedido = await this.repository.update(id, {
+      estado: nuevoEstado,
+      updatedAt: new Date()
+    })
+
+    if (nuevoEstado === 'RECIBIDO') {
+      const updatedObra = await prisma.obra.update({
+        where: { cod_obra: pedido.obraId },
+        data: { estado: 'PAGADA PARCIALMENTE' }
+      })
+      eventBus.emit('obra.cambio_estado', { cod_obra: pedido.obraId, nuevo_estado: updatedObra.estado })
+    }
+
+    return updatedPedido
+  }
+}

--- a/src/shared/middlewares/authorizationRoles.ts
+++ b/src/shared/middlewares/authorizationRoles.ts
@@ -23,7 +23,7 @@ export const PERMISSIONS = {
     verNotasFabrica: ['COORDINACION', 'PRODUCCION', 'VENTAS', 'VISITADOR'],
     verConPresupuestoAceptado: ['VENTAS'],
     solicitarStock: ['COORDINACION'],
-    recibirStock: ['PRODUCCION'],
+    iniciarProduccion: ['PRODUCCION'],
     finalizarProduccion: ['PRODUCCION', 'COORDINACION'],
     gestionarNotaFabrica: ['COORDINACION', 'PRODUCCION', 'VENTAS'],
     crear: ['VENTAS'],
@@ -112,6 +112,11 @@ export const PERMISSIONS = {
     crear: ['COORDINACION'],
     actualizar: ['COORDINACION'],
     eliminar: ['COORDINACION'],
+  },
+  pedidoStock: {
+    crear: ['PRODUCCION', 'COORDINACION'],
+    actualizarEstado: ['COORDINACION'],
+    obtener: ['COORDINACION', 'PRODUCCION'],
   },
 } as const satisfies Record<string, Record<string, readonly UserRole[]>>
 

--- a/src/shared/routes/index.routes.ts
+++ b/src/shared/routes/index.routes.ts
@@ -43,6 +43,7 @@ import visitaEmpleadoRouter from '../../models/VisitaEmpleado/visitaEmpleado.rou
 
 import routeMid from '../../models/midlewareTest/mid.routes.js'
 import provinciaRouter from '../../models/Provincia/provincia.routes.js'
+import pedidoStockRouter from '../../models/PedidoStock/pedidoStock.routes.js'
 
 router.use('/api/empleados', empleadoRouter)
 router.use('/api/vehiculos', vehiculoRouter)
@@ -63,6 +64,7 @@ router.use('/api/visitas', visitaRouter)
 router.use('/api/entrega-empleado', entregaEmpleadoRouter)
 router.use('/api/empleado-visita', visitaEmpleadoRouter)
 router.use('/api/provincias', provinciaRouter)
+router.use('/api/pedido-stock', pedidoStockRouter)
 
 router.use((req, res) => {
   res.status(404).json({


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
No aplica

---

### Resumen
Este PR añade la entidad `PedidoStock` y establece las bases para manejar el estado de las obras frente a escasez de materiales, permitiendo a Producción y Coordinación un control estricto sobre el flujo de inventario y el inicio de la fabricación.

### Cambios Técnicos Implementados
- **Nueva Entidad `PedidoStock`:** Creación del Controller, Service, Repository y Routes para gestionar CRUD completo y transiciones (PENDIENTE -> APROBADO -> PEDIDO -> RECIBIDO).
- **Control de Estados en Obra:** 
  - Se añadió la transición mediante `iniciarProduccion` (estado `PAGADA PARCIALMENTE` a `EN PRODUCCION`).
  - Se eliminaron filtros restrictivos en `ObraRepository.findObrasParaPedidoStock` que evitaban visualizar obras de clientes físicos.
- **Seguridad y Permisos:** Actualización de `authorizationRoles.ts` para proteger las rutas del nuevo módulo `PedidoStock` de manera acorde a cada rol.
- **Testing:** Se actualizaron los tests del `obra.service.spec.ts` para contemplar la refactorización de los nombres de los métodos de las transiciones.

---

### Guía para Pruebas y Revisión
1. Iniciar el servidor de base de datos y correr migraciones (si aplicara) para que el schema actualice.
2. Hacer una petición a `GET /api/pedido-stock` asegurándose de tener un token con rol válido de Producción o Coordinación.
3. Probar la creación de un nuevo pedido (`POST /api/pedido-stock`) sobre una obra con estado `PAGADA PARCIALMENTE`.
4. Verificar que se pueda actualizar el estado del pedido a `RECIBIDO` y constatar que se persista la información correctamente.
5. Correr los tests unitarios ejecutando `npm run test` (o similar) comprobando que las pruebas de Obra aprueban.
ntalla del "antes" y el "después". -->