### PR TITLE
Fix: Eliminación de fallback de CUIL y normalización estricta al crear registros

### DIFF
--- a/src/models/Cliente/cliente.service.ts
+++ b/src/models/Cliente/cliente.service.ts
@@ -53,19 +53,8 @@ export class ClienteService {
   }
 
   async findById(cuil: string): Promise<cliente> {
-    const cuilNormalized = cuil.split("-").join("")
-    let cliente = await this.repository.findById(cuilNormalized)
-    
-    let cuilConGuiones = cuil
-    if (!cliente && cuil.length === 11 && !cuil.includes('-')) {
-      cuilConGuiones = `${cuil.slice(0, 2)}-${cuil.slice(2, 10)}-${cuil.slice(10)}`
-      cliente = await this.repository.findById(cuilConGuiones)
-    }
-
-    if (!cliente && cuil !== cuilNormalized && cuil !== cuilConGuiones) {
-      // Fallback por si llega con guiones pero no fue encontrado en los pasos anteriores
-      cliente = await this.repository.findById(cuil)
-    }
+    const cuilNormalized = cuil.replace(/-/g, '')
+    const cliente = await this.repository.findById(cuilNormalized)
 
     if (!cliente) {
       throw new AppError('Cliente no encontrado', 404, 'CLIENTE_NOT_FOUND')

--- a/src/models/Empleado/empleado.repository.ts
+++ b/src/models/Empleado/empleado.repository.ts
@@ -63,20 +63,10 @@ export class EmpleadoRepository {
     })
   }
 
-  // Helper para generar variaciones del CUIL
-  private getCuilVariations(cuil: string): string[] {
-    const cuilNormalized = cuil.split('-').join('')
-    let cuilConGuiones = cuil
-    if (cuilNormalized.length === 11) {
-      cuilConGuiones = `${cuilNormalized.slice(0, 2)}-${cuilNormalized.slice(2, 10)}-${cuilNormalized.slice(10)}`
-    }
-    return [cuilNormalized, cuilConGuiones, cuil]
-  }
-
   // Obtener empleado por CUIL (solo datos públicos)
   async findByCuilPublic(cuil: string): Promise<EmpleadoPayload | null> {
-    return await this.prisma.empleado.findFirst({
-      where: { cuil: { in: this.getCuilVariations(cuil) } },
+    return await this.prisma.empleado.findUnique({
+      where: { cuil: cuil },
       select: {
         cuil: true,
         nombre: true,
@@ -89,14 +79,14 @@ export class EmpleadoRepository {
   }
   // Obtener empleado por CUIL
   async findByCuil(cuil: string): Promise<empleado | null> {
-    return await this.prisma.empleado.findFirst({
-      where: { cuil: { in: this.getCuilVariations(cuil) } },
+    return await this.prisma.empleado.findUnique({
+      where: { cuil: cuil },
     })
   }
 
   async findPerfil(cuil: string): Promise<EmpleadoPayload | null> {
-    return await this.prisma.empleado.findFirst({
-      where: { cuil: { in: this.getCuilVariations(cuil) } },
+    return await this.prisma.empleado.findUnique({
+      where: { cuil: cuil },
       select: {
         cuil: true,
         nombre: true,
@@ -209,8 +199,8 @@ export class EmpleadoRepository {
 
   // Verificar si existe empleado por CUIL
   async existsByCuil(cuil: string): Promise<boolean> {
-    const empleado = await this.prisma.empleado.findFirst({
-      where: { cuil: { in: this.getCuilVariations(cuil) } },
+    const empleado = await this.prisma.empleado.findUnique({
+      where: { cuil: cuil },
       select: { cuil: true },
     })
     return !!empleado

--- a/src/models/Empleado/empleado.service.ts
+++ b/src/models/Empleado/empleado.service.ts
@@ -86,7 +86,8 @@ export class EmpleadoService {
     area_trabajo: string
     contrasenia?: string
   }): Promise<EmpleadoPayload> {
-    const existingEmpleado = await this.empleadoRepository.findByCuil(data.cuil)
+    const cuilNormalized = data.cuil.replace(/-/g, '')
+    const existingEmpleado = await this.empleadoRepository.findByCuil(cuilNormalized)
     if (existingEmpleado) {
       throw new AppError('Ya existe un empleado con ese CUIL', 409, 'CONFLICTO_CUIL')
     }
@@ -97,7 +98,7 @@ export class EmpleadoService {
       : null
 
     const empleadoResult = await this.empleadoRepository.create({
-      cuil: data.cuil,
+      cuil: cuilNormalized,
       nombre: data.nombre,
       apellido: data.apellido,
       rol_actual: data.rol_actual,


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este PR.
-->
Eliminación de la lógica de "fallback" para la búsqueda de CUILs con guiones, forzando la normalización estricta tanto en las búsquedas como en la creación de empleados.

---

### Cambios Técnicos Implementados
<!--
Detalla los cambios más importantes a nivel código, como nuevas tablas, migraciones, 
cambios en los controladores/servicios, etc.
-->
- **Limpieza en Repositorios y Servicios:** Se eliminó la lógica de variaciones de CUIL en `EmpleadoRepository.ts` y en `ClienteService.ts`, volviendo a utilizar las búsquedas directas sin intentar coincidir con formatos antiguos (con guiones).
- **Creación Normalizada:** Se añadió una limpieza forzosa (`.replace(/-/g, '')`) en el método `create` de `EmpleadoService.ts` para garantizar que todos los registros nuevos se inserten puramente como números en la BD, independientemente de lo que envíe el cliente.

---

### Verificación y Pruebas
<!--
Marca con una "X" (ej. [X]) lo que corresponda y añade detalles de cómo lo probaste.
-->
- [x] El código ha sido compilado localmente y no presenta errores.
- [x] Se eliminó con éxito el soporte legacy de guiones.
- [x] La creación de empleados normaliza el string correctamente antes de interactuar con Prisma.
