### PR TITLE
Refactor/op nf flow

### DIFF
--- a/src/models/Obra/obra.controller.ts
+++ b/src/models/Obra/obra.controller.ts
@@ -10,6 +10,7 @@ const obraService = new ObraService()
 type NotasFabricaEstado = NotasFabricaFilters['estado']
 const NOTAS_FABRICA_ESTADOS = [
   'SIN_ORDEN',
+  'CON_ORDEN',
   'EN_PRODUCCION',
   'FINALIZADA',
 ] as const
@@ -129,7 +130,7 @@ export class ObraController {
     if (
       !NOTAS_FABRICA_ESTADOS.includes(normalizedEstado as NotasFabricaEstado)
     ) {
-      throw new AppError('El estado debe ser SIN_ORDEN, EN_PRODUCCION o FINALIZADA', 400, 'INVALID_STATE')
+      throw new AppError('El estado debe ser SIN_ORDEN, CON_ORDEN, EN_PRODUCCION o FINALIZADA', 400, 'INVALID_STATE')
     }
 
     const fechaDesdeDate = normalizedFechaDesde ? new Date(normalizedFechaDesde) : null

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -4,6 +4,7 @@ import type { PaginationParams } from '../../shared/types/pagination.js'
 
 export type NotasFabricaEstado =
   | 'SIN_ORDEN'
+  | 'CON_ORDEN'
   | 'EN_PRODUCCION'
   | 'FINALIZADA'
 
@@ -199,6 +200,7 @@ export class ObraRepository {
     ]
 
     if (filters.estado === 'SIN_ORDEN') {
+      // Tiene nota de fábrica pero ninguna orden de producción asociada
       andConditions.push({
         orden_de_produccion: {
           none: {},
@@ -211,10 +213,35 @@ export class ObraRepository {
       })
     }
 
-    if (filters.estado === 'EN_PRODUCCION') {
+    if (filters.estado === 'CON_ORDEN') {
+      // Tiene al menos una orden, pero ninguna está en EN PRODUCCION
+      // (la obra todavía no empezó producción)
       andConditions.push({
         orden_de_produccion: {
           some: {},
+        },
+      })
+      andConditions.push({
+        orden_de_produccion: {
+          none: {
+            estado: 'EN PRODUCCION',
+          },
+        },
+      })
+      andConditions.push({
+        estado: {
+          notIn: ['EN PRODUCCION', 'PRODUCCION FINALIZADA', 'CANCELADA'],
+        },
+      })
+    }
+
+    if (filters.estado === 'EN_PRODUCCION') {
+      // Tiene al menos una orden en estado EN PRODUCCION (y la obra está EN PRODUCCION)
+      andConditions.push({
+        orden_de_produccion: {
+          some: {
+            estado: 'EN PRODUCCION',
+          },
         },
       })
       andConditions.push({

--- a/src/models/Obra/obra.repository.ts
+++ b/src/models/Obra/obra.repository.ts
@@ -236,18 +236,11 @@ export class ObraRepository {
     }
 
     if (filters.estado === 'EN_PRODUCCION') {
-      // Tiene al menos una orden en estado EN PRODUCCION (y la obra está EN PRODUCCION)
+      // La obra está EN PRODUCCION: usa el estado de la OBRA como fuente de verdad.
+      // Una obra en producción permanece aquí hasta que Producción la finaliza
+      // explícitamente (→ PRODUCCION FINALIZADA), sin importar el estado de sus OPs.
       andConditions.push({
-        orden_de_produccion: {
-          some: {
-            estado: 'EN PRODUCCION',
-          },
-        },
-      })
-      andConditions.push({
-        estado: {
-          notIn: ['PRODUCCION FINALIZADA', 'CANCELADA'],
-        },
+        estado: 'EN PRODUCCION',
       })
     }
 
@@ -286,6 +279,7 @@ export class ObraRepository {
         },
         presupuesto: true,
         pago: true,
+        pedido_stock: true,
       },
     })
   }

--- a/src/models/Obra/obra.service.spec.ts
+++ b/src/models/Obra/obra.service.spec.ts
@@ -46,12 +46,12 @@ describe('ObraService - Pruebas Unitarias', () => {
     it('debería fallar si el estado no es PAGADA PARCIALMENTE', async () => {
       vi.spyOn(ObraRepository.prototype, 'findById').mockResolvedValue({
         cod_obra: 1,
-        estado: 'PENDIENTE',
+        estado: 'EN ESPERA DE PAGO',
       } as unknown as Awaited<ReturnType<ObraRepository['findById']>>)
       await expect(obraService.iniciarProduccion(1)).rejects.toThrow('Esta obra no está lista para iniciar producción (Debe estar pagada parcialmente y tener stock).')
     })
 
-    it('debería cambiar a EN PRODUCCION exitosamente', async () => {
+    it('debería cambiar a EN PRODUCCION exitosamente cuando está PAGADA PARCIALMENTE', async () => {
       vi.spyOn(ObraRepository.prototype, 'findById').mockResolvedValue({
         cod_obra: 2,
         estado: 'PAGADA PARCIALMENTE',

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -42,6 +42,32 @@ export class OrdenProduccionService {
       throw new ValidationError('Código de obra inválido', 'INVALID_ID')
     }
 
+    // Validar que la obra existe y tiene el estado correcto para crear una OP
+    const obra = await prisma.obra.findUnique({ where: { cod_obra: codObra } })
+    if (!obra) {
+      throw new ValidationError(`Obra no encontrada (ID: ${codObra})`, 'OBRA_NOT_FOUND')
+    }
+    if (obra.estado !== 'PAGADA PARCIALMENTE') {
+      throw new ValidationError(
+        'Solo se puede crear una Orden de Producción para obras con pago parcial.',
+        'INVALID_STATE'
+      )
+    }
+
+    // Validar que la obra no tenga un pedido de stock pendiente
+    const pedidoPendiente = await prisma.pedido_stock.findFirst({
+      where: {
+        obraId: codObra,
+        estado: { not: 'RECIBIDO' },
+      },
+    })
+    if (pedidoPendiente) {
+      throw new ValidationError(
+        'La obra tiene un pedido de stock pendiente. Debe resolverse antes de crear una Orden de Producción.',
+        'PENDING_STOCK_REQUEST'
+      )
+    }
+
     const normalizedUrl = (uploadedFile?.path ?? data.url ?? '').trim()
     if (!normalizedUrl) {
       throw new ValidationError('No se ha subido ningún archivo', 'FILE_REQUIRED')


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
Ejemplo: "Este PR refactoriza el módulo `student` para alinearlo con la arquitectura moderna del proyecto."
-->
Corrige la lógica de negocio del flujo Nota de Fábrica → Orden de Producción: las validaciones de creación de OP ahora viven en el backend, y el filtro de notas en producción usa el estado de la obra como fuente de verdad.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
- **Validación:** Se ha añadido validación de entrada para `x` usando `y`.
- **Refactorización del Controlador:** Se ha aislado la lógica de negocio en el servicio, asegurando el uso de `await`.
- **Seguridad:** Se ha aplicado el `authMiddleware` a las nuevas rutas.
-->
- Validación en OrdenProduccionService.create(): Se verifica que la obra exista, esté en PAGADA PARCIALMENTE y no tenga un pedido de stock pendiente (estado ≠ RECIBIDO) antes de crear una OP.
- Corrección de filtro EN_PRODUCCION: findNotasFabrica con estado EN_PRODUCCION ahora filtra por obra.estado = 'EN PRODUCCION' en lugar de buscar OPs individuales en ese estado, evitando que las notas desaparezcan al finalizar una OP.
- pedido_stock incluido en findNotasFabrica: Se agrega al include para que el frontend no necesite un request separado.
- Tests obra.service.spec.ts: Se actualiza iniciarProduccion() con estado inicial realista (EN ESPERA DE PAGO) y se agrega comentario documentando que la transición real ocurre vía OrdenProduccionService.
---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
1.  Iniciar el servidor.
2.  Obtener un token JWT válido.
3.  Probar el endpoint `GET /api/...` con un token válido.
4.  **Verificar Fallos:** Intentar acceder al mismo endpoint sin token (esperado: 401 Unauthorized).
-->
1. Intentar crear una OP sobre una obra que no esté en PAGADA PARCIALMENTE → esperar 400 INVALID_STATE.
2. Intentar crear una OP sobre una obra con pedido de stock activo → esperar 400 PENDING_STOCK_REQUEST.
3. Crear OP → aprobarla → iniciar producción → finalizar la OP → verificar que la nota de fábrica sigue visible en la columna "En Producción".