### PR TITLE
feat: resubir op update

### DIFF
--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -79,7 +79,16 @@ export class OrdenProduccionController {
     const codOpNum = Number(cod_op)
     if (isNaN(codOpNum)) throw new AppError('Código de orden inválido', 400, 'INVALID_ID')
 
-    const orden = await ordenProduccionService.update(codOpNum, req.body)
+    if (!req.file) {
+      throw new AppError('No se ha proporcionado el archivo de orden de producción', 400, 'FILE_REQUIRED')
+    }
+
+    const updateData = {
+      url: req.file.path,
+      public_id: req.file.filename,
+    }
+
+    const orden = await ordenProduccionService.update(codOpNum, updateData)
     return sendSuccess(res, orden, 'Production order updated successfully')
   })
 

--- a/src/models/OrdenProduccion/ordenProduccion.routes.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.routes.ts
@@ -24,7 +24,7 @@ ordenProduccionRouter.post('/:cod_op/finalizar', authorize('OP', 'actualizar'), 
 
 ordenProduccionRouter.get('/:cod_op', ordenProduccionController.getOne)
 
-ordenProduccionRouter.put('/:cod_op', authorize('OP', 'actualizar'), ordenProduccionController.update)
+ordenProduccionRouter.patch('/:cod_op', authorize('OP', 'actualizar'), upload.single('file'), ordenProduccionController.update)
 
 ordenProduccionRouter.delete('/:cod_op', authorize('OP', 'eliminar'), ordenProduccionController.remove)
 


### PR DESCRIPTION
### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
Ejemplo: "Este PR refactoriza el módulo `student` para alinearlo con la arquitectura moderna del proyecto."
-->

Esta pr adapta el backend para permitir resubir una OP cumpliendo con el CUU-6

### Cambios Técnicos Implementados

- Soporte para `PATCH /api/ordenes-produccion/:cod_op` con `upload.single('file')`.
- Validación de `req.file` para asegurar que se suba un PDF antes de actualizar.
- Actualización de la orden de producción para guardar el nuevo `url` y `public_id`.
- Corrección para evitar el error de Prisma por `data` vacío en `prisma.orden_de_produccion.update`.

