### PR TITLE
Feature/op visita linking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,12 +86,12 @@ model provincia {
 }
 
 model localidad {
-  nombre_localidad String      @db.VarChar(255)
-  cod_localidad    Int         @id @default(autoincrement())
+  nombre_localidad String    @db.VarChar(255)
+  cod_localidad    Int       @id @default(autoincrement())
   cod_provincia    Int
-  provincia        provincia   @relation(fields: [cod_provincia], references: [cod_provincia], onDelete: NoAction, onUpdate: NoAction)
-  visita           visita[]
+  provincia        provincia @relation(fields: [cod_provincia], references: [cod_provincia], onDelete: NoAction, onUpdate: NoAction)
   obra             obra[]
+  visita           visita[]
 }
 
 model maquinaria {
@@ -124,8 +124,8 @@ model obra {
   pedido_stock         pedido_stock?
   presupuesto          presupuesto[]
   uso_maquinaria       uso_maquinaria[]
-  visita               visita[]
   uso_vehiculo_entrega uso_vehiculo_entrega[]
+  visita               visita[]
 }
 
 model orden_de_produccion {
@@ -138,10 +138,10 @@ model orden_de_produccion {
   estado           String    @default("PENDIENTE") @db.VarChar(255)
   cod_entrega      Int?
   cod_visita       Int?
-  motivo_rechazo   String?   @db.Text
+  motivo_rechazo   String?
   entrega          entrega?  @relation(fields: [cod_entrega], references: [cod_entrega])
-  visita           visita?   @relation(fields: [cod_visita], references: [cod_visita])
   obra             obra      @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  visita           visita?   @relation(fields: [cod_visita], references: [cod_visita])
 }
 
 model pago {
@@ -221,24 +221,24 @@ model vehiculo {
 }
 
 model visita {
-  fecha_hora_visita   DateTime              @db.Timestamp(6)
-  cod_obra            Int?
-  fecha_cancelacion   DateTime?             @db.Date
-  observaciones       String?               @db.VarChar(500)
-  motivo_visita       String                @db.VarChar(50)
-  estado              String                @db.VarChar(50)
-  direccion_visita    String?               @db.VarChar(500)
-  cod_visita          Int                   @id @default(autoincrement())
-  apellido_cliente    String?               @db.VarChar(50)
-  cod_localidad       Int?
-  dias_viatico        Int?
-  nombre_cliente      String?               @db.VarChar(50)
-  telefono_cliente    String?               @db.VarChar(20)
-  empleado_visita     empleado_visita[]
-  uso_vehiculo_visita uso_vehiculo_visita[]
-  localidad           localidad?            @relation(fields: [cod_localidad], references: [cod_localidad], onDelete: NoAction, onUpdate: NoAction)
-  obra                obra?                 @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  fecha_hora_visita     DateTime              @db.Timestamp(6)
+  cod_obra              Int?
+  fecha_cancelacion     DateTime?             @db.Date
+  observaciones         String?               @db.VarChar(500)
+  motivo_visita         String                @db.VarChar(50)
+  estado                String                @db.VarChar(50)
+  direccion_visita      String?               @db.VarChar(500)
+  cod_visita            Int                   @id @default(autoincrement())
+  apellido_cliente      String?               @db.VarChar(50)
+  cod_localidad         Int?
+  dias_viatico          Int?
+  nombre_cliente        String?               @db.VarChar(50)
+  telefono_cliente      String?               @db.VarChar(20)
+  empleado_visita       empleado_visita[]
   ordenes_de_produccion orden_de_produccion[]
+  uso_vehiculo_visita   uso_vehiculo_visita[]
+  localidad             localidad?            @relation(fields: [cod_localidad], references: [cod_localidad], onDelete: NoAction, onUpdate: NoAction)
+  obra                  obra?                 @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([cod_obra])
   @@index([cod_localidad])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,7 +137,9 @@ model orden_de_produccion {
   public_id        String?   @db.VarChar(255)
   estado           String    @default("PENDIENTE") @db.VarChar(255)
   cod_entrega      Int?
+  cod_visita       Int?
   entrega          entrega?  @relation(fields: [cod_entrega], references: [cod_entrega])
+  visita           visita?   @relation(fields: [cod_visita], references: [cod_visita])
   obra             obra      @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
 }
 
@@ -235,6 +237,7 @@ model visita {
   uso_vehiculo_visita uso_vehiculo_visita[]
   localidad           localidad?            @relation(fields: [cod_localidad], references: [cod_localidad], onDelete: NoAction, onUpdate: NoAction)
   obra                obra?                 @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)
+  ordenes_de_produccion orden_de_produccion[]
 
   @@index([cod_obra])
   @@index([cod_localidad])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,7 @@ model orden_de_produccion {
   estado           String    @default("PENDIENTE") @db.VarChar(255)
   cod_entrega      Int?
   cod_visita       Int?
+  motivo_rechazo   String?   @db.Text
   entrega          entrega?  @relation(fields: [cod_entrega], references: [cod_entrega])
   visita           visita?   @relation(fields: [cod_visita], references: [cod_visita])
   obra             obra      @relation(fields: [cod_obra], references: [cod_obra], onDelete: NoAction, onUpdate: NoAction)

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express'
 import { OrdenProduccionService } from './ordenProduccion.service.js'
 import { catchAsync } from '../../shared/utils/catchAsync.js'
-import { sendSuccess } from '../../shared/utils/apiResponse.js'
+import { sendSuccess, sendPaginatedSuccess } from '../../shared/utils/apiResponse.js'
+import { parsePagination } from '../../shared/utils/parsePagination.js'
 import { AppError } from '../../shared/errors/AppError.js'
 
 const ordenProduccionService = new OrdenProduccionService()
@@ -36,11 +37,12 @@ export class OrdenProduccionController {
    */
   getAll = catchAsync(async (req: Request, res: Response) => {
     const { cod_obra, estado } = req.query
-    const ordenes = await ordenProduccionService.findAll({
+    const pagination = parsePagination(req.query as Record<string, unknown>)
+    const result = await ordenProduccionService.findAll({
       cod_obra: cod_obra ? Number(cod_obra) : undefined,
       estado: estado as string | undefined,
-    })
-    return sendSuccess(res, ordenes)
+    }, pagination)
+    return sendPaginatedSuccess(res, result as any)
   })
 
   /**

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -42,7 +42,7 @@ export class OrdenProduccionController {
       cod_obra: cod_obra ? Number(cod_obra) : undefined,
       estado: estado as string | undefined,
     }, pagination)
-    return sendPaginatedSuccess(res, result as any)
+    return sendPaginatedSuccess(res, result)
   })
 
   /**

--- a/src/models/OrdenProduccion/ordenProduccion.controller.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.controller.ts
@@ -165,4 +165,17 @@ export class OrdenProduccionController {
     return sendSuccess(res, orden, 'Production order finalized successfully')
   })
 
+  /**
+   * Rejects a production order.
+   */
+  rechazar = catchAsync(async (req: Request, res: Response) => {
+    const { cod_op } = req.params
+    const { motivo } = req.body
+    const codOpNum = Number(cod_op)
+    if (isNaN(codOpNum)) throw new AppError('Código de orden inválido', 400, 'INVALID_ID')
+
+    const orden = await ordenProduccionService.rechazar(codOpNum, motivo)
+    return sendSuccess(res, orden, 'Production order rejected successfully')
+  })
+
 }

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -54,6 +54,15 @@ export class OrdenProduccionRepository {
       where: andConditions.length ? { AND: andConditions } : undefined,
       orderBy: { fecha_confeccion: 'desc' },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -71,6 +80,15 @@ export class OrdenProduccionRepository {
     return await this.prisma.orden_de_produccion.findUnique({
       where: { cod_op },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -91,6 +109,15 @@ export class OrdenProduccionRepository {
       },
       orderBy: { fecha_validacion: 'desc' },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -111,6 +138,15 @@ export class OrdenProduccionRepository {
       },
       orderBy: { fecha_validacion: 'desc' },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -129,6 +165,15 @@ export class OrdenProduccionRepository {
       where: {cod_obra},
       orderBy: { fecha_confeccion: 'desc' },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -151,6 +196,15 @@ export class OrdenProduccionRepository {
       },
       orderBy: { fecha_confeccion: 'desc' },
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,
@@ -172,6 +226,15 @@ export class OrdenProduccionRepository {
       where: { cod_op },
       data,
       include: {
+        visita: {
+          include: {
+            empleado_visita: {
+              include: {
+                empleado: true,
+              },
+            },
+          },
+        },
         obra: {
           include: {
             cliente: true,

--- a/src/models/OrdenProduccion/ordenProduccion.repository.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.repository.ts
@@ -23,7 +23,10 @@ export class OrdenProduccionRepository {
     })
   }
 
-  async findAll(filters?: OrdenProduccionFilters): Promise<orden_de_produccion[]> {
+  async findAll(
+    filters?: OrdenProduccionFilters,
+    pagination?: { page: number; pageSize: number },
+  ): Promise<{ data: orden_de_produccion[]; total: number }> {
     const andConditions: Prisma.orden_de_produccionWhereInput[] = []
 
     if (filters?.estado) {
@@ -50,30 +53,41 @@ export class OrdenProduccionRepository {
       andConditions.push({ fecha_confeccion: fechaConfeccionFilter })
     }
 
-    return await this.prisma.orden_de_produccion.findMany({
-      where: andConditions.length ? { AND: andConditions } : undefined,
-      orderBy: { fecha_confeccion: 'desc' },
-      include: {
-        visita: {
-          include: {
-            empleado_visita: {
-              include: {
-                empleado: true,
+    const where = andConditions.length ? { AND: andConditions } : undefined
+    const skip = pagination ? (pagination.page - 1) * pagination.pageSize : undefined
+    const take = pagination ? pagination.pageSize : undefined
+
+    const [data, total] = await Promise.all([
+      this.prisma.orden_de_produccion.findMany({
+        where,
+        orderBy: { fecha_confeccion: 'desc' },
+        include: {
+          visita: {
+            include: {
+              empleado_visita: {
+                include: {
+                  empleado: true,
+                },
+              },
+            },
+          },
+          obra: {
+            include: {
+              cliente: true,
+              localidad: true,
+              visita: {
+                orderBy: { fecha_hora_visita: 'desc' },
               },
             },
           },
         },
-        obra: {
-          include: {
-            cliente: true,
-            localidad: true,
-            visita: {
-              orderBy: { fecha_hora_visita: 'desc' },
-            },
-          },
-        },
-      },
-    })
+        skip,
+        take,
+      }),
+      this.prisma.orden_de_produccion.count({ where }),
+    ])
+
+    return { data, total }
   }
 
   async findById(cod_op: number): Promise<orden_de_produccion | null> {

--- a/src/models/OrdenProduccion/ordenProduccion.routes.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.routes.ts
@@ -25,7 +25,7 @@ ordenProduccionRouter.post('/:cod_op/finalizar', authorize('OP', 'actualizar'), 
 ordenProduccionRouter.get('/:cod_op', ordenProduccionController.getOne)
 
 ordenProduccionRouter.patch('/:cod_op/aprobar', authorize('OP', 'actualizar'), ordenProduccionController.aprobar)
-
+ordenProduccionRouter.patch('/:cod_op/rechazar', authorize('OP', 'actualizar'), ordenProduccionController.rechazar)
 ordenProduccionRouter.patch('/:cod_op', authorize('OP', 'actualizar'), upload.single('file'), ordenProduccionController.update)
 
 ordenProduccionRouter.delete('/:cod_op', authorize('OP', 'eliminar'), ordenProduccionController.remove)

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -132,6 +132,15 @@ export class OrdenProduccionService {
     data: Prisma.orden_de_produccionUpdateInput,
   ): Promise<orden_de_produccion> {
     const orden = await this.findById(cod_op) // Ensure existence
+
+    // Si la orden estaba rechazada, al resubir el archivo (update) 
+    // la volvemos a PENDIENTE y limpiamos el motivo
+    if (orden.estado === 'RECHAZADA') {
+      data.estado = 'PENDIENTE'
+      data.motivo_rechazo = null
+      data.fecha_confeccion = new Date()
+    }
+
     const nuevaOrden = await this.repository.update(cod_op, data)
 
     // Emitir evento si la orden de producción acaba de ser aprobada
@@ -147,13 +156,41 @@ export class OrdenProduccionService {
    */
   async aprobar(cod_op: number): Promise<orden_de_produccion> {
     const orden = await this.findById(cod_op)
-    if (orden.estado !== 'PENDIENTE') {
+    if (orden.estado !== 'PENDIENTE' && orden.estado !== 'RECHAZADA') {
       throw new ValidationError(
-        'Solo las órdenes en estado "Pendiente" pueden ser aprobadas.',
+        'Solo las órdenes en estado "Pendiente" o "Rechazada" pueden ser aprobadas.',
         'INVALID_STATE'
       )
     }
-    const ordenActualizada = await this.repository.update(cod_op, { estado: 'APROBADA' })
+    const ordenActualizada = await this.repository.update(cod_op, { 
+      estado: 'APROBADA',
+      motivo_rechazo: null // Limpiamos por las dudas
+    })
+    return ordenActualizada
+  }
+
+  /**
+   * Rejects a production order with a reason.
+   */
+  async rechazar(cod_op: number, motivo: string): Promise<orden_de_produccion> {
+    const orden = await this.findById(cod_op)
+    
+    if (orden.estado !== 'PENDIENTE') {
+      throw new ValidationError(
+        'Solo las órdenes en estado "Pendiente" pueden ser rechazadas.',
+        'INVALID_STATE'
+      )
+    }
+
+    if (!motivo || motivo.trim().length === 0) {
+      throw new ValidationError('Debe proporcionar un motivo para el rechazo.', 'MOTIVO_REQUIRED')
+    }
+
+    const ordenActualizada = await this.repository.update(cod_op, {
+      estado: 'RECHAZADA',
+      motivo_rechazo: motivo
+    })
+
     return ordenActualizada
   }
 

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -95,6 +95,11 @@ export class OrdenProduccionService {
    * Gets all production orders with optional filters.
    */
   async findAll(
+    filters: OrdenProduccionFilters | undefined,
+    pagination: PaginationParams,
+  ): Promise<PaginatedResponse<orden_de_produccion>>
+  async findAll(filters?: OrdenProduccionFilters): Promise<orden_de_produccion[]>
+  async findAll(
     filters?: OrdenProduccionFilters,
     pagination?: PaginationParams,
   ): Promise<PaginatedResponse<orden_de_produccion> | orden_de_produccion[]> {

--- a/src/models/OrdenProduccion/ordenProduccion.service.ts
+++ b/src/models/OrdenProduccion/ordenProduccion.service.ts
@@ -7,6 +7,7 @@ import { prisma } from '../../shared/db/prismaClient.js'
 import { AppError } from '../../shared/errors/AppError.js'
 import { ValidationError } from '../../shared/errors/validationError.js'
 import { eventBus } from '../../shared/events/eventBus.js'
+import type { PaginationParams, PaginatedResponse } from '../../shared/types/pagination.js'
 
 interface OrdenProduccionCreateInput {
   cod_obra: number | string
@@ -95,8 +96,21 @@ export class OrdenProduccionService {
    */
   async findAll(
     filters?: OrdenProduccionFilters,
-  ): Promise<orden_de_produccion[]> {
-    return this.repository.findAll(filters)
+    pagination?: PaginationParams,
+  ): Promise<PaginatedResponse<orden_de_produccion> | orden_de_produccion[]> {
+    const { data, total } = await this.repository.findAll(filters, pagination)
+
+    if (pagination) {
+      return {
+        data,
+        total,
+        totalPages: Math.ceil(total / pagination.pageSize),
+        page: pagination.page,
+        pageSize: pagination.pageSize,
+      }
+    }
+
+    return data
   }
 
   /**

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -21,6 +21,7 @@ export type VisitaWithRelations = Prisma.visitaGetPayload<{
         vehiculo: true,
       },
     },
+    ordenes_de_produccion: true,
   },
 }>
 
@@ -62,6 +63,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       }
 
     const [data, total] = await Promise.all([
@@ -102,6 +104,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       },
     }) as VisitaWithRelations | null
   }
@@ -128,6 +131,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       },
     }) as VisitaWithRelations
   }
@@ -160,6 +164,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       },
     }) as VisitaWithRelations
   }
@@ -196,6 +201,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       },
     }) as VisitaWithRelations[]
   }
@@ -378,6 +384,7 @@ export class VisitaRepository {
               vehiculo: true,
             },
           },
+          ordenes_de_produccion: true,
         },
         orderBy: {
           fecha_hora_visita: 'desc',
@@ -471,6 +478,7 @@ export class VisitaRepository {
               vehiculo: true,
             },
           },
+          ordenes_de_produccion: true,
         },
         orderBy: {
           fecha_hora_visita: 'desc',
@@ -520,6 +528,7 @@ export class VisitaRepository {
             vehiculo: true,
           },
         },
+        ordenes_de_produccion: true,
       }
 
     const [data, total] = await Promise.all([

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -27,6 +27,7 @@ interface CreateVisitaData {
   cod_localidad?: number
   vehiculo: string
   fechaHasta?: string
+  cod_ops?: number[]
 }
 
 /**
@@ -97,6 +98,11 @@ export class VisitaService {
             ),
             fecha_hora_fin_est: fechaFinEstimada,
           },
+        },
+      }),
+      ...(data.cod_ops && data.cod_ops.length > 0 && {
+        ordenes_de_produccion: {
+          connect: data.cod_ops.map((cod_op) => ({ cod_op })),
         },
       }),
     }


### PR DESCRIPTION
### Issue Relacionada

---

### Resumen
Implementación del motor lógico para el flujo de rechazo de Órdenes de Producción (OP), permitiendo el almacenamiento de feedback y el reinicio automático del ciclo de validación.

### Cambios Técnicos Implementados
- **Esquema Prisma**: Se añadió el campo `motivo_rechazo` (String) al modelo `orden_de_produccion` para persistir el feedback de Coordinación.
- **OrdenProduccionService**: 
    - Implementación de `rechazar(cod_op, motivo)` con validación de estado (`PENDIENTE`).
    - Mejora en `update`: Se añadió lógica de "reinicio" que devuelve la OP al estado `PENDIENTE` y limpia el `motivo_rechazo` cuando se sube un nuevo archivo corrector.
- **API Endpoints**: Se añadió la ruta `PATCH /:cod_op/rechazar` vinculada al controlador y protegida por permisos de actualización de OP.

---

### Guía para Pruebas y Revisión
1. Ejecutar `npx prisma db push` para actualizar la base de datos local con el nuevo campo.
2. **Caso Éxito (Rechazo)**: Como coordinador, enviar una petición `PATCH` a `/rechazar` con un motivo. Verificar en DB que el estado cambie a `RECHAZADA`.
3. **Caso Éxito (Corrección)**: Como producción, realizar un `PATCH` de actualización (resubir archivo) sobre una orden rechazada. Verificar que el estado vuelva a `PENDIENTE` y el motivo de rechazo sea `null`.
4. **Verificar Fallos**: Intentar rechazar una orden que ya está `APROBADA` o `EN PRODUCCION` (debe lanzar error de estado inválido).
