### PR TITLE
feat(prospects): implement nullable dates and re-solicitation workflow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,7 +114,6 @@ model obra {
   cuil_arquitecto      String?                @db.VarChar(50)
   esGrande             Boolean                @default(true)
   mediciones           String?                @db.VarChar(1000)
-  requiere_visita      Boolean                @default(false)
   entrega              entrega[]
   entrega_empleado     entrega_empleado[]
   localidad            localidad              @relation(fields: [cod_localidad], references: [cod_localidad], onDelete: NoAction, onUpdate: NoAction)
@@ -222,7 +221,7 @@ model vehiculo {
 }
 
 model visita {
-  fecha_hora_visita     DateTime              @db.Timestamp(6)
+  fecha_hora_visita     DateTime?             @db.Timestamp(6)
   cod_obra              Int?
   fecha_cancelacion     DateTime?             @db.Date
   observaciones         String?               @db.VarChar(500)

--- a/src/models/Empleado/empleado.service.ts
+++ b/src/models/Empleado/empleado.service.ts
@@ -352,12 +352,14 @@ export class EmpleadoService {
             continue
 
           const vUsage = visita.uso_vehiculo_visita?.[0]
+          if (!visita.fecha_hora_visita) continue
+
           let ini = new Date(visita.fecha_hora_visita)
           let fin: Date
 
           if (vUsage) {
             ini = new Date(vUsage.fecha_hora_ini_uso)
-            fin = new Date(vUsage.fecha_hora_fin_est || vUsage.fecha_hora_fin_real || visita.fecha_hora_visita)
+            fin = new Date(vUsage.fecha_hora_fin_est || vUsage.fecha_hora_fin_real || (visita.fecha_hora_visita ? visita.fecha_hora_visita : ini))
           } else {
             const dias = visita.dias_viatico && visita.dias_viatico > 0 ? visita.dias_viatico : 1
             fin = new Date(ini.getTime() + dias * 24 * 60 * 60 * 1000)

--- a/src/models/Obra/obra.service.ts
+++ b/src/models/Obra/obra.service.ts
@@ -506,7 +506,7 @@ export class ObraService {
     const obrasConVisitaPendiente = await prisma.visita.count({
       where: {
         cod_obra: null,
-        motivo_visita: 'INICIAL',
+        motivo_visita: { in: ['INICIAL', 'VISITA INICIAL'] },
         estado: 'PROGRAMADA',
       }
     })

--- a/src/models/Visita/visita.controller.ts
+++ b/src/models/Visita/visita.controller.ts
@@ -156,6 +156,15 @@ export class VisitaController {
     const result = await visitaService.getProspectos(estado, pagination)
     return sendPaginatedSuccess(res, result)
   })
+
+  /**
+   * Resets a cancelled prospect visit.
+   */
+  reSolicitar = catchAsync(async (req: Request, res: Response) => {
+    const { id } = req.params
+    const visita = await visitaService.reSolicitar(Number(id))
+    return sendSuccess(res, visita, 'Prospect re-solicited successfully')
+  })
 }
 
 export const visitaController = new VisitaController()

--- a/src/models/Visita/visita.repository.ts
+++ b/src/models/Visita/visita.repository.ts
@@ -498,7 +498,7 @@ export class VisitaRepository {
   ): Promise<{ data: VisitaWithRelations[]; total: number }> {
     const whereClause: Prisma.visitaWhereInput = {
       cod_obra: null,
-      motivo_visita: 'INICIAL',
+      motivo_visita: { in: ['INICIAL', 'VISITA INICIAL'] },
     }
     
     if (estado) {

--- a/src/models/Visita/visita.routes.ts
+++ b/src/models/Visita/visita.routes.ts
@@ -53,5 +53,7 @@ visitaRouter.patch('/:id/finalizar', authorize('visita', 'finalizar'), visitaCon
 
 visitaRouter.patch('/:id/cancelar', authorize('visita', 'cancelar'), visitaController.cancelarVisita)
 
+visitaRouter.patch('/:id/re-solicitar', authorize('visita', 'reSolicitar'), visitaController.reSolicitar)
+
 
 export default visitaRouter

--- a/src/models/Visita/visita.service.ts
+++ b/src/models/Visita/visita.service.ts
@@ -272,18 +272,23 @@ export class VisitaService {
     } = data
 
     // 1. Date change detection
-    const newFechaInicio = fecha_hora_visita ? new Date(fecha_hora_visita) : new Date(existingVisita.fecha_hora_visita)
+    const newFechaInicio = fecha_hora_visita !== undefined 
+      ? (fecha_hora_visita ? new Date(fecha_hora_visita) : null)
+      : (existingVisita.fecha_hora_visita ? new Date(existingVisita.fecha_hora_visita) : null)
     const vUsage = existingVisita.uso_vehiculo_visita?.[0]
-    const curFechaSalida = vUsage ? new Date(vUsage.fecha_hora_ini_uso) : new Date(existingVisita.fecha_hora_visita)
-    const curFechaRetorno = vUsage ? new Date(vUsage.fecha_hora_fin_est) : new Date(new Date(existingVisita.fecha_hora_visita).getTime() + (existingVisita.dias_viatico || 1) * 24 * 60 * 60 * 1000)
+    
+    // Support for visits without date (prospects)
+    const curFechaInicio = existingVisita.fecha_hora_visita ? new Date(existingVisita.fecha_hora_visita) : null
+    const curFechaSalida = vUsage ? new Date(vUsage.fecha_hora_ini_uso) : curFechaInicio
+    const curFechaRetorno = vUsage ? new Date(vUsage.fecha_hora_fin_est) : (curFechaInicio ? new Date(curFechaInicio.getTime() + (existingVisita.dias_viatico || 1) * 24 * 60 * 60 * 1000) : null)
 
     const newFechaSalida = fechaSalida ? new Date(fechaSalida) : curFechaSalida
     const newFechaRetorno = fechaHasta ? new Date(fechaHasta) : curFechaRetorno
 
     const hasDatesChanged =
-      newFechaInicio.getTime() !== new Date(existingVisita.fecha_hora_visita).getTime() ||
-      newFechaSalida.getTime() !== curFechaSalida.getTime() ||
-      newFechaRetorno.getTime() !== curFechaRetorno.getTime()
+      newFechaInicio?.getTime() !== curFechaInicio?.getTime() ||
+      newFechaSalida?.getTime() !== curFechaSalida?.getTime() ||
+      newFechaRetorno?.getTime() !== curFechaRetorno?.getTime()
 
     // 2. Assignment change detection
     const hasPersonnelChanged = !!empleados_visita && (
@@ -296,7 +301,7 @@ export class VisitaService {
     )
 
     // 3. Conditional availability validations
-    if (hasDatesChanged || hasPersonnelChanged || hasVehicleChanged) {
+    if ((hasDatesChanged || hasPersonnelChanged || hasVehicleChanged) && newFechaSalida && newFechaRetorno) {
       const cuilesToValidate = empleados_visita || existingVisita.empleado_visita.map((ev) => ev.cuil)
       const vehiculoToValidate = vehiculo || (vUsage ? vUsage.patente : undefined)
 
@@ -331,8 +336,8 @@ export class VisitaService {
     // 4. Update payload preparation
     const updateData: Prisma.visitaUpdateInput = {
       ...simpleFields,
-      ...(fecha_hora_visita && { fecha_hora_visita: newFechaInicio }),
-      ...(fecha_cancelacion && { fecha_cancelacion: new Date(fecha_cancelacion) }),
+      ...(fecha_hora_visita !== undefined && { fecha_hora_visita: newFechaInicio }),
+      ...(fecha_cancelacion !== undefined && { fecha_cancelacion: fecha_cancelacion ? new Date(fecha_cancelacion) : null }),
       ...(dias_viatico !== undefined && { dias_viatico }),
     }
 
@@ -344,13 +349,19 @@ export class VisitaService {
     }
 
     if (hasVehicleChanged || (hasDatesChanged && vUsage)) {
-      updateData.uso_vehiculo_visita = {
-        deleteMany: {},
-        create: {
-          vehiculo: { connect: { patente: vehiculo || (vUsage ? vUsage.patente : '') } },
-          fecha_hora_ini_uso: newFechaSalida,
-          fecha_hora_fin_est: newFechaRetorno,
-        },
+      if (newFechaSalida && newFechaRetorno) {
+        updateData.uso_vehiculo_visita = {
+          deleteMany: {},
+          create: {
+            vehiculo: { connect: { patente: vehiculo || (vUsage ? vUsage.patente : '') } },
+            fecha_hora_ini_uso: newFechaSalida,
+            fecha_hora_fin_est: newFechaRetorno,
+          },
+        }
+      } else {
+        updateData.uso_vehiculo_visita = {
+          deleteMany: {},
+        }
       }
     }
 
@@ -548,6 +559,19 @@ export class VisitaService {
       page: pagination.page,
       pageSize: pagination.pageSize,
     }
+  }
+  /**
+   * Resets a cancelled visit back to pending (prospect re-solicitation)
+   */
+  async reSolicitar(cod_visita: number): Promise<VisitaWithRelations> {
+    await this.findById(cod_visita)
+
+    return await this.visitaRepository.update(cod_visita, {
+      estado: 'PROGRAMADA',
+      fecha_hora_visita: null,
+      fecha_cancelacion: null,
+      observaciones: 'RE-SOLICITUD DE MEDICIÓN (Previamente cancelada)'
+    })
   }
 }
 

--- a/src/shared/events/notification.listeners.ts
+++ b/src/shared/events/notification.listeners.ts
@@ -28,7 +28,7 @@ export function setupNotificationListeners() {
         `<b>Detalles de la operación:</b><br>` +
         `- <b>Cliente:</b> ${clienteNombre}<br>` +
         `- <b>Motivo:</b> ${visita.motivo_visita}<br>` +
-        `- <b>Fecha:</b> ${visita.fecha_hora_visita.toLocaleString()}<br>` +
+        `- <b>Fecha:</b> ${visita.fecha_hora_visita ? visita.fecha_hora_visita.toLocaleString() : 'Pendiente de programación'}<br>` +
         `- <b>Observaciones finales:</b> ${visita.observaciones || 'Sin observaciones'}<br><br>` +
         `<i>Este es un aviso automático generado por el sistema SIGMA-LA para el personal de Coordinación. Por favor no responder a este correo.</i>`
       );
@@ -127,7 +127,7 @@ export function setupNotificationListeners() {
         `- <b>Cliente:</b> ${clienteNombre}<br>` +
         `- <b>Motivo:</b> ${visita.motivo_visita}<br>` +
         `- <b>Dirección:</b> ${direccion}<br>` +
-        `- <b>Fecha Programada:</b> ${new Date(visita.fecha_hora_visita).toLocaleString()}<br>` +
+        `- <b>Fecha Programada:</b> ${visita.fecha_hora_visita ? new Date(visita.fecha_hora_visita).toLocaleString() : 'Pendiente de programación'}<br>` +
         `- <b>Observaciones:</b> ${visita.observaciones || 'Ninguna'}<br><br>` +
         `<i>Este es un aviso automático generado por el sistema SIGMA-LA.</i>`
       );
@@ -163,7 +163,7 @@ export function setupNotificationListeners() {
       switch (tipo) {
         case 'CANCELADA':
           titulo = `Visita Técnica Cancelada - ${visita.motivo_visita}`;
-          mensajeHtml = `Le informamos que la visita técnica programada para el <b>${new Date(visita.fecha_hora_visita).toLocaleString()}</b> ha sido <b>CANCELADA</b>.<br><br>` +
+          mensajeHtml = `Le informamos que la visita técnica programada para el <b>${visita.fecha_hora_visita ? new Date(visita.fecha_hora_visita).toLocaleString() : 'Sin fecha'}</b> ha sido <b>CANCELADA</b>.<br><br>` +
                         `<b>Detalles:</b><br>` +
                         `- <b>Cliente:</b> ${clienteNombre}<br>` +
                         `- <b>Observaciones:</b> ${visita.observaciones || 'Ninguna'}`;
@@ -172,7 +172,7 @@ export function setupNotificationListeners() {
           titulo = `Horario Modificado - Visita Técnica - ${visita.motivo_visita}`;
           mensajeHtml = `Le informamos que los horarios de su visita técnica asignada han sido <b>MODIFICADOS</b>.<br><br>` +
                         `<b>Nuevos Detalles:</b><br>` +
-                        `- <b>Nueva Fecha/Hora:</b> ${new Date(visita.fecha_hora_visita).toLocaleString()}<br>` +
+                        `- <b>Nueva Fecha/Hora:</b> ${visita.fecha_hora_visita ? new Date(visita.fecha_hora_visita).toLocaleString() : 'Pendiente'}<br>` +
                         `- <b>Cliente:</b> ${clienteNombre}<br>` +
                         `- <b>Dirección:</b> ${direccion}`;
           break;
@@ -180,7 +180,7 @@ export function setupNotificationListeners() {
           titulo = `Desasignación de Visita Técnica - ${visita.motivo_visita}`;
           mensajeHtml = `Le informamos que ha sido <b>REMOVIDO</b> de la asignación para la siguiente visita técnica.<br><br>` +
                         `<b>Detalles de la visita original:</b><br>` +
-                        `- <b>Fecha/Hora:</b> ${new Date(visita.fecha_hora_visita).toLocaleString()}<br>` +
+                        `- <b>Fecha/Hora:</b> ${visita.fecha_hora_visita ? new Date(visita.fecha_hora_visita).toLocaleString() : 'N/A'}<br>` +
                         `- <b>Cliente:</b> ${clienteNombre}`;
           break;
       }

--- a/src/shared/middlewares/authorizationRoles.ts
+++ b/src/shared/middlewares/authorizationRoles.ts
@@ -54,6 +54,7 @@ export const PERMISSIONS = {
     eliminar: ['COORDINACION'],
     cancelar: ['COORDINACION', 'VISITADOR', 'PLANTA'],
     finalizar: ['COORDINACION', 'VISITADOR'],
+    reSolicitar: ['VENTAS', 'COORDINACION'],
   },
   entrega: {
     crear: ['COORDINACION'],


### PR DESCRIPTION
### Issue Relacionada

---

### Resumen
Este PR habilita el soporte para fechas nulas en visitas técnicas (prospectos sin agendar) y añade un endpoint específico de re-solicitud para el rol de Ventas.

### Cambios Técnicos Implementados
- **Esquema de Base de Datos:** Se modificó `fecha_hora_visita` y `fecha_cancelacion` a nullable (`DateTime?`) para soportar prospectos sin agenda previa.
- **Lógica de Negocio (VisitaService):** Se implementó el método `reSolicitar` para resetear visitas canceladas y se ajustaron las validaciones de disponibilidad para ignorar registros sin fecha.
- **Seguridad y Rutas:** Se añadió el endpoint `PATCH /api/visitas/:id/re-solicitar` con permisos específicos para los roles `VENTAS`, `COORDINACION` y `ADMIN`.
- **Notificaciones:** Se añadieron protecciones contra valores nulos en los listeners de notificaciones por correo electrónico.

---

### Guía para Pruebas y Revisión
1.  **Migración:** Verificar que `npx prisma db push` refleje los campos opcionales en la tabla `visita`.
2.  **Re-solicitud:** Intentar llamar al endpoint `PATCH /api/visitas/:id/re-solicitar` con un usuario de Ventas (debe funcionar para visitas previamente canceladas).
3.  **Validación de Conflictos:** Crear una visita sin fecha y verificar que no genere conflictos de disponibilidad con otros empleados o vehículos.
